### PR TITLE
Create profiles when the unit is created and give implicit roles

### DIFF
--- a/src/main/java/fr/siamois/domain/services/InstitutionService.java
+++ b/src/main/java/fr/siamois/domain/services/InstitutionService.java
@@ -321,7 +321,12 @@ public class InstitutionService {
      * @return true if the person was added successfully, false if they were already an action manager
      */
     public boolean addPersonToActionManager(InstitutionDTO institution, PersonDTO person) {
-        return personProfileAssignmentService.addToActionManagers(institution, person);
+        List<ProfileDTO> profiles = new ArrayList<>();
+        Profile institutionProjectManager = profileService.createOrGetOrganizationProjectManagerProfile(institution);
+        Profile institutionMember =  profileService.createOrGetOrganizationMemberProfile(institution);
+        profiles.add(profileMapper.convert(institutionProjectManager));
+        profiles.add(profileMapper.convert(institutionMember));
+        return personProfileAssignmentService.addToInstitution(institution, person, profiles) != null;
     }
 
 

--- a/src/main/java/fr/siamois/domain/services/InstitutionService.java
+++ b/src/main/java/fr/siamois/domain/services/InstitutionService.java
@@ -7,6 +7,7 @@ import fr.siamois.domain.models.exceptions.institution.FailedInstitutionSaveExce
 import fr.siamois.domain.models.exceptions.institution.InstitutionAlreadyExistException;
 import fr.siamois.domain.models.institution.Institution;
 import fr.siamois.domain.models.permissions.PermissionConstants;
+import fr.siamois.domain.models.permissions.Profile;
 import fr.siamois.domain.models.permissions.ProfileConstants;
 import fr.siamois.domain.models.settings.InstitutionSettings;
 import fr.siamois.domain.models.vocabulary.Concept;
@@ -18,12 +19,14 @@ import fr.siamois.domain.services.vocabulary.VocabularyService;
 import fr.siamois.dto.entity.ActionUnitDTO;
 import fr.siamois.dto.entity.InstitutionDTO;
 import fr.siamois.dto.entity.PersonDTO;
+import fr.siamois.dto.entity.ProfileDTO;
 import fr.siamois.infrastructure.database.repositories.institution.InstitutionRepository;
 import fr.siamois.infrastructure.database.repositories.permissions.PersonProfileAssignmentRepository;
 import fr.siamois.infrastructure.database.repositories.person.PersonRepository;
 import fr.siamois.infrastructure.database.repositories.settings.InstitutionSettingsRepository;
 import fr.siamois.mapper.InstitutionMapper;
 import fr.siamois.mapper.PersonMapper;
+import fr.siamois.mapper.ProfileMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,10 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -55,6 +55,7 @@ public class InstitutionService {
     private final PersonProfileAssignmentService personProfileAssignmentService;
     private final PersonProfileAssignmentRepository personProfileAssignmentRepository;
     private final ProfileService profileService;
+    private final ProfileMapper profileMapper;
 
     /**
      * Finds an institution by its identifier.
@@ -174,23 +175,6 @@ public class InstitutionService {
     }
 
     /**
-     * Adds a user to an institution with a specific role.
-     *
-     * @param person      the person to add to the institution
-     * @param institution the institution to which the person will be added
-     * @param roleConcept the role concept that defines the person's role in the institution
-     * @throws FailedInstitutionSaveException if there is an error while saving the institution
-     */
-    public void addUserToInstitution(Person person, Institution institution, Concept roleConcept) throws FailedInstitutionSaveException {
-        try {
-            personRepository.addPersonToInstitution(person.getId(), institution.getId(), roleConcept.getId());
-        } catch (Exception e) {
-            log.error("Failed to add user to institution", e);
-            throw new FailedInstitutionSaveException("Failed to add user to institution");
-        }
-    }
-
-    /**
      * Creates or retrieves the settings for a given institution.
      *
      * @param institution the institution for which to create or retrieve settings
@@ -223,7 +207,12 @@ public class InstitutionService {
      */
     @Transactional
     public boolean addToManagers(InstitutionDTO institution, PersonDTO person) {
-        return personProfileAssignmentService.addToManagers(institution, person);
+        Profile member = profileService.createOrGetOrganizationMemberProfile(institution);
+        Profile institutionManager = profileService.createOrGetOrganizationManagerProfile(institution);
+        List<ProfileDTO> profiles =  new ArrayList<>();
+        profiles.add(profileMapper.convert(member));
+        profiles.add(profileMapper.convert(institutionManager));
+        return personProfileAssignmentService.addToInstitution(institution, person, profiles) != null;
     }
 
 

--- a/src/main/java/fr/siamois/domain/services/InstitutionService.java
+++ b/src/main/java/fr/siamois/domain/services/InstitutionService.java
@@ -12,6 +12,7 @@ import fr.siamois.domain.models.settings.InstitutionSettings;
 import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.models.vocabulary.Vocabulary;
 import fr.siamois.domain.services.permissions.PersonProfileAssignmentService;
+import fr.siamois.domain.services.permissions.ProfileService;
 import fr.siamois.domain.services.vocabulary.FieldConfigurationService;
 import fr.siamois.domain.services.vocabulary.VocabularyService;
 import fr.siamois.dto.entity.ActionUnitDTO;
@@ -53,6 +54,7 @@ public class InstitutionService {
     private final InstitutionMapper institutionMapper;
     private final PersonProfileAssignmentService personProfileAssignmentService;
     private final PersonProfileAssignmentRepository personProfileAssignmentRepository;
+    private final ProfileService profileService;
 
     /**
      * Finds an institution by its identifier.
@@ -129,8 +131,10 @@ public class InstitutionService {
             // Verifier que le thesaurus soit compatible
 
             Institution i = institutionRepository.save(Objects.requireNonNull(institutionMapper.invertConvert(institution)));
-            fieldConfigurationService.setupFieldConfigurationForInstitution(institutionMapper.convert(i), vocabulary);
-            return institutionMapper.convert(i);
+            fieldConfigurationService.setupFieldConfigurationForInstitution(Objects.requireNonNull(institutionMapper.convert(i)), vocabulary);
+            InstitutionDTO institutionDTO = institutionMapper.convert(i);
+            createInstitutionProfiles(institutionDTO);
+            return  institutionDTO;
         } catch (NotSiamoisThesaurusException e) {
             log.error("The thesaurus is not a siamois thesaurus : {}", thesaurusUrl, e);
             throw e;
@@ -138,6 +142,12 @@ public class InstitutionService {
             log.error("Error while saving institution", e);
             throw new FailedInstitutionSaveException("Failed to save institution");
         }
+    }
+
+    private void createInstitutionProfiles(InstitutionDTO institutionDTO) {
+        profileService.createOrGetOrganizationManagerProfile(institutionDTO);
+        profileService.createOrGetOrganizationProjectManagerProfile(institutionDTO);
+        profileService.createOrGetOrganizationMemberProfile(institutionDTO);
     }
 
 

--- a/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
+++ b/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
@@ -14,6 +14,7 @@ import fr.siamois.domain.models.institution.Institution;
 import fr.siamois.domain.models.spatialunit.SpatialUnit;
 import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.services.ArkEntityService;
+import fr.siamois.domain.services.permissions.ProfileService;
 import fr.siamois.domain.services.vocabulary.ConceptService;
 import fr.siamois.dto.FilterDTO;
 import fr.siamois.dto.api.AccessibleProjectForApi;
@@ -76,7 +77,7 @@ public class ActionUnitService implements ArkEntityService {
     private final PendingActionUnitRepository pendingActionUnitRepository;
     private final RecordingUnitIdCounterRepository recordingUnitIdCounterRepository;
     private final RecordingUnitIdLabelRepository recordingUnitIdLabelRepository;
-
+    private final ProfileService profileService;
 
 
     /**
@@ -97,6 +98,11 @@ public class ActionUnitService implements ArkEntityService {
             log.error(e.getMessage(), e);
             throw e;
         }
+    }
+
+    private void createProjectProfiles(ActionUnitDTO actionUnitDTO) {
+        profileService.createOrGetProjectManagerProfile(actionUnitDTO);
+        profileService.createOrGetProjectMemberProfile(actionUnitDTO);
     }
 
     /**
@@ -206,7 +212,9 @@ public class ActionUnitService implements ArkEntityService {
     @CacheEvict(value = "MyActionUnits", allEntries = true)
     public ActionUnitDTO save(UserInfo info, ActionUnitDTO actionUnit, ConceptDTO typeConcept)
             throws ActionUnitAlreadyExistsException {
-        return actionUnitMapper.convert(saveNotTransactional(info, actionUnit, typeConcept));
+        ActionUnitDTO savedDTO = actionUnitMapper.convert(saveNotTransactional(info, actionUnit, typeConcept));
+        createProjectProfiles(savedDTO);
+        return savedDTO;
     }
 
     /**

--- a/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
+++ b/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
@@ -221,14 +221,14 @@ public class ActionUnitService implements ArkEntityService {
     public ActionUnitDTO save(UserInfo info, ActionUnitDTO actionUnit, ConceptDTO typeConcept)
             throws ActionUnitAlreadyExistsException {
         ActionUnitDTO savedDTO = actionUnitMapper.convert(saveNotTransactional(info, actionUnit, typeConcept));
-        assignRoles(info, actionUnit, savedDTO);
+        assignRoles(info, savedDTO);
         return savedDTO;
     }
 
-    private void assignRoles(UserInfo info, ActionUnitDTO actionUnit, ActionUnitDTO savedDTO) {
+    private void assignRoles(UserInfo info, ActionUnitDTO savedDTO) {
         Map<String, Profile> profiles = createProjectProfiles(savedDTO);
-        assignAsOrganisationMember(info, actionUnit);
-        assignAsProjectMember(info, actionUnit, profiles);
+        assignAsOrganisationMember(info, savedDTO);
+        assignAsProjectMember(info, savedDTO, profiles);
     }
 
     private void assignAsProjectMember(UserInfo info, ActionUnitDTO actionUnit, Map<String, Profile> profiles) {

--- a/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
+++ b/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
@@ -221,12 +221,28 @@ public class ActionUnitService implements ArkEntityService {
     public ActionUnitDTO save(UserInfo info, ActionUnitDTO actionUnit, ConceptDTO typeConcept)
             throws ActionUnitAlreadyExistsException {
         ActionUnitDTO savedDTO = actionUnitMapper.convert(saveNotTransactional(info, actionUnit, typeConcept));
+        assignRoles(info, actionUnit, savedDTO);
+        return savedDTO;
+    }
+
+    private void assignRoles(UserInfo info, ActionUnitDTO actionUnit, ActionUnitDTO savedDTO) {
         Map<String, Profile> profiles = createProjectProfiles(savedDTO);
+        assignAsOrganisationMember(info, actionUnit);
+        assignAsProjectMember(info, actionUnit, profiles);
+    }
+
+    private void assignAsProjectMember(UserInfo info, ActionUnitDTO actionUnit, Map<String, Profile> profiles) {
         List<ProfileDTO> profileDTOS = new ArrayList<>();
         profileDTOS.add(profileMapper.convert(profiles.get(ProfileConstants.PROJECT_MANAGER)));
         profileDTOS.add(profileMapper.convert(profiles.get(ProfileConstants.PROJECT_MEMBER)));
         personProfileAssignmentService.addToProjectMembers(actionUnit, info.getUser(), profileDTOS);
-        return savedDTO;
+    }
+
+    private void assignAsOrganisationMember(UserInfo info, ActionUnitDTO actionUnit) {
+        Profile institutionMember = profileService.createOrGetOrganizationMemberProfile(actionUnit.getCreatedByInstitution());
+        List<ProfileDTO> institutionMemberProfileDTOS = new ArrayList<>();
+        institutionMemberProfileDTOS.add(profileMapper.convert(institutionMember));
+        personProfileAssignmentService.addToInstitution(actionUnit.getCreatedByInstitution(), info.getUser(), institutionMemberProfileDTOS);
     }
 
     /**

--- a/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
+++ b/src/main/java/fr/siamois/domain/services/actionunit/ActionUnitService.java
@@ -11,9 +11,12 @@ import fr.siamois.domain.models.exceptions.actionunit.ActionUnitNotFoundExceptio
 import fr.siamois.domain.models.exceptions.actionunit.FailedActionUnitSaveException;
 import fr.siamois.domain.models.exceptions.actionunit.NullActionUnitIdentifierException;
 import fr.siamois.domain.models.institution.Institution;
+import fr.siamois.domain.models.permissions.Profile;
+import fr.siamois.domain.models.permissions.ProfileConstants;
 import fr.siamois.domain.models.spatialunit.SpatialUnit;
 import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.services.ArkEntityService;
+import fr.siamois.domain.services.permissions.PersonProfileAssignmentService;
 import fr.siamois.domain.services.permissions.ProfileService;
 import fr.siamois.domain.services.vocabulary.ConceptService;
 import fr.siamois.dto.FilterDTO;
@@ -33,6 +36,7 @@ import fr.siamois.infrastructure.database.repositories.specs.ActionUnitSpec;
 import fr.siamois.mapper.ActionUnitMapper;
 import fr.siamois.mapper.ConceptMapper;
 import fr.siamois.mapper.PersonMapper;
+import fr.siamois.mapper.ProfileMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -78,6 +82,8 @@ public class ActionUnitService implements ArkEntityService {
     private final RecordingUnitIdCounterRepository recordingUnitIdCounterRepository;
     private final RecordingUnitIdLabelRepository recordingUnitIdLabelRepository;
     private final ProfileService profileService;
+    private final PersonProfileAssignmentService personProfileAssignmentService;
+    private final ProfileMapper profileMapper;
 
 
     /**
@@ -100,9 +106,11 @@ public class ActionUnitService implements ArkEntityService {
         }
     }
 
-    private void createProjectProfiles(ActionUnitDTO actionUnitDTO) {
-        profileService.createOrGetProjectManagerProfile(actionUnitDTO);
-        profileService.createOrGetProjectMemberProfile(actionUnitDTO);
+    private Map<String, Profile> createProjectProfiles(ActionUnitDTO actionUnitDTO) {
+        Map<String, Profile> projectProfiles = new HashMap<>();
+        projectProfiles.put(ProfileConstants.PROJECT_MANAGER, profileService.createOrGetProjectManagerProfile(actionUnitDTO));
+        projectProfiles.put(ProfileConstants.PROJECT_MEMBER, profileService.createOrGetProjectMemberProfile(actionUnitDTO));
+        return projectProfiles;
     }
 
     /**
@@ -213,7 +221,11 @@ public class ActionUnitService implements ArkEntityService {
     public ActionUnitDTO save(UserInfo info, ActionUnitDTO actionUnit, ConceptDTO typeConcept)
             throws ActionUnitAlreadyExistsException {
         ActionUnitDTO savedDTO = actionUnitMapper.convert(saveNotTransactional(info, actionUnit, typeConcept));
-        createProjectProfiles(savedDTO);
+        Map<String, Profile> profiles = createProjectProfiles(savedDTO);
+        List<ProfileDTO> profileDTOS = new ArrayList<>();
+        profileDTOS.add(profileMapper.convert(profiles.get(ProfileConstants.PROJECT_MANAGER)));
+        profileDTOS.add(profileMapper.convert(profiles.get(ProfileConstants.PROJECT_MEMBER)));
+        personProfileAssignmentService.addToProjectMembers(actionUnit, info.getUser(), profileDTOS);
         return savedDTO;
     }
 

--- a/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
+++ b/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
@@ -79,7 +79,7 @@ public class PersonProfileAssignmentService {
             profileSet.add(profileMapper.convert(member));
         }
 
-        Profile institutionMemberProfile = profileService.createOrGetProjectMemberProfile(project);
+        Profile institutionMemberProfile = profileService.createOrGetOrganizationMemberProfile(project.getCreatedByInstitution());
         assignProfile(institutionMemberProfile, personToAdd);
 
         for (ProfileDTO profile : profiles) {

--- a/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
+++ b/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
@@ -12,9 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -49,21 +47,24 @@ public class PersonProfileAssignmentService {
 
     public InstitutionMemberDTO addToInstitution(InstitutionDTO institution, PersonDTO person, List<ProfileDTO> profiles) {
         int i = 0;
+        Set<ProfileDTO> profileSet = new HashSet<>();
         Person personToAdd = personMapper.invertConvert(person);
         while (i < profiles.size() && !profiles.get(i).getCode().equals(ProfileConstants.ORGANIZATION_MEMBER)) i++;
         if (i == profiles.size()) {
             Profile member = profileService.createOrGetOrganizationMemberProfile(institution);
             assignProfile(member, personToAdd);
+            profileSet.add(profileMapper.convert(member));
         }
 
         for (ProfileDTO profile : profiles) {
             Profile currentProfile = profileMapper.invertConvert(profile);
             assignProfile(currentProfile, personToAdd);
+            profileSet.add(profileMapper.convert(currentProfile));
         }
 
         InstitutionMemberDTO institutionMemberDTO = new InstitutionMemberDTO();
         institutionMemberDTO.setPerson(person);
-        institutionMemberDTO.setProfiles(profiles);
+        institutionMemberDTO.setProfiles(new ArrayList<>(profileSet));
         return institutionMemberDTO;
     }
 

--- a/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
+++ b/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,29 +25,26 @@ public class PersonProfileAssignmentService {
     private final ProfileService profileService;
     private final ProfileMapper profileMapper;
 
-    private boolean assignProfile(@NonNull Profile profile, @NonNull Person person) {
+    private void assignProfile(@NonNull Profile profile, @NonNull Person person) {
         Optional<PersonProfileAssignment> opt = personProfileAssignmentRepository.findByProfileIdAndPersonId(profile.getId(), person.getId());
-        if (opt.isPresent()) return false;
+        if (opt.isPresent()) return;
         PersonProfileAssignment assignment = new PersonProfileAssignment();
         assignment.setProfile(profile);
         assignment.setPerson(person);
         personProfileAssignmentRepository.save(assignment);
-        return true;
     }
 
     public boolean addToManagers(InstitutionDTO institution, PersonDTO person) {
         Profile organizationManagers = profileService.createOrGetOrganizationManagerProfile(institution);
-        return assignProfile(organizationManagers, personMapper.invertConvert(person));
-    }
-
-    public boolean addToActionManagers(InstitutionDTO institution, PersonDTO person) {
-        Profile projectManagers = profileService.createOrGetOrganizationProjectManagerProfile(institution);
-        return assignProfile(projectManagers, personMapper.invertConvert(person));
+        Profile organizationMember = profileService.createOrGetOrganizationMemberProfile(institution);
+        List<ProfileDTO> profiles = new ArrayList<>();
+        profiles.add(profileMapper.convert(organizationManagers));
+        profiles.add(profileMapper.convert(organizationMember));
+        return addToInstitution(institution, person, profiles) != null;
     }
 
     public boolean addToProjectMembers(ActionUnitDTO actionUnit, PersonDTO person) {
-        Profile projectMembers = profileService.createOrGetProjectMemberProfile(actionUnit);
-        return assignProfile(projectMembers, personMapper.invertConvert(person));
+        return addToProjectMembers(actionUnit, person, List.of()) != null;
     }
 
     public InstitutionMemberDTO addToInstitution(InstitutionDTO institution, PersonDTO person, List<ProfileDTO> profiles) {
@@ -77,6 +75,10 @@ public class PersonProfileAssignmentService {
             Profile member = profileService.createOrGetProjectMemberProfile(project);
             assignProfile(member, personToAdd);
         }
+
+        Profile institutionMemberProfile = profileService.createOrGetProjectMemberProfile(project);
+        assignProfile(institutionMemberProfile, personToAdd);
+
         for (ProfileDTO profile : profiles) {
             Profile currentProfile = profileMapper.invertConvert(profile);
             assignProfile(currentProfile, personToAdd);

--- a/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
+++ b/src/main/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentService.java
@@ -70,11 +70,13 @@ public class PersonProfileAssignmentService {
 
     public ProjectMemberDTO addToProjectMembers(ActionUnitDTO project, PersonDTO person, List<ProfileDTO> profiles) {
         int i = 0;
+        Set<ProfileDTO> profileSet = new HashSet<>();
         Person personToAdd = personMapper.invertConvert(person);
         while (i < profiles.size() && !profiles.get(i).getCode().equals(ProfileConstants.PROJECT_MEMBER)) i++;
         if (i == profiles.size()) {
             Profile member = profileService.createOrGetProjectMemberProfile(project);
             assignProfile(member, personToAdd);
+            profileSet.add(profileMapper.convert(member));
         }
 
         Profile institutionMemberProfile = profileService.createOrGetProjectMemberProfile(project);
@@ -83,11 +85,12 @@ public class PersonProfileAssignmentService {
         for (ProfileDTO profile : profiles) {
             Profile currentProfile = profileMapper.invertConvert(profile);
             assignProfile(currentProfile, personToAdd);
+            profileSet.add(profileMapper.convert(currentProfile));
         }
 
         ProjectMemberDTO projectMemberDTO = new ProjectMemberDTO();
         projectMemberDTO.setPerson(person);
-        projectMemberDTO.setProfiles(profiles);
+        projectMemberDTO.setProfiles(new ArrayList<>(profileSet));
         return projectMemberDTO;
     }
 

--- a/src/main/java/fr/siamois/infrastructure/database/repositories/permissions/PersonProfileAssignmentRepository.java
+++ b/src/main/java/fr/siamois/infrastructure/database/repositories/permissions/PersonProfileAssignmentRepository.java
@@ -138,7 +138,7 @@ public interface PersonProfileAssignmentRepository extends CrudRepository<Person
             SELECT ppa FROM PersonProfileAssignment ppa
             JOIN FETCH ppa.person p
             JOIN FETCH ppa.profile prof
-            WHERE prof.institution.id = :institutionId
+            WHERE prof.institution.id = :institutionId AND prof.actionUnit IS NULL
             """)
     List<PersonProfileAssignment> findAllAssignmentsByInstitutionId(@Param("institutionId") Long institutionId);
 

--- a/src/test/java/fr/siamois/domain/services/ActionUnitServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/ActionUnitServiceTest.java
@@ -15,6 +15,8 @@ import fr.siamois.domain.models.institution.Institution;
 import fr.siamois.domain.models.spatialunit.SpatialUnit;
 import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.services.actionunit.ActionUnitService;
+import fr.siamois.domain.services.permissions.PersonProfileAssignmentService;
+import fr.siamois.domain.services.permissions.ProfileService;
 import fr.siamois.domain.services.vocabulary.ConceptService;
 import fr.siamois.dto.FilterDTO;
 import fr.siamois.dto.api.AccessibleProjectForApi;
@@ -33,6 +35,7 @@ import fr.siamois.infrastructure.database.repositories.specs.ActionUnitSpec;
 import fr.siamois.mapper.ActionUnitMapper;
 import fr.siamois.mapper.ConceptMapper;
 import fr.siamois.mapper.PersonMapper;
+import fr.siamois.mapper.ProfileMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,6 +77,9 @@ class ActionUnitServiceTest {
     @Mock private PendingActionUnitRepository pendingActionUnitRepository;
     @Mock private RecordingUnitIdCounterRepository recordingUnitIdCounterRepository;
     @Mock private RecordingUnitIdLabelRepository recordingUnitIdLabelRepository;
+    @Mock private ProfileService profileService;
+    @Mock private PersonProfileAssignmentService personProfileAssignmentService;
+    @Mock private ProfileMapper profileMapper;
     @InjectMocks
     private ActionUnitService actionUnitService;
 
@@ -295,6 +301,8 @@ class ActionUnitServiceTest {
         verify(personMapper).invertConvert(personDto);
         verify(actionUnitRepository).save(actionUnit);
         verify(actionUnitMapper).convert(actionUnit);
+        verify(personProfileAssignmentService).addToProjectMembers(eq(expectedResult), eq(personDto), anyList());
+        verify(personProfileAssignmentService).addToInstitution(eq(institutionDto), eq(personDto), anyList());
     }
 
 

--- a/src/test/java/fr/siamois/domain/services/InstitutionServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/InstitutionServiceTest.java
@@ -8,6 +8,7 @@ import fr.siamois.domain.models.exceptions.api.NotSiamoisThesaurusException;
 import fr.siamois.domain.models.exceptions.institution.FailedInstitutionSaveException;
 import fr.siamois.domain.models.exceptions.institution.InstitutionAlreadyExistException;
 import fr.siamois.domain.models.institution.Institution;
+import fr.siamois.domain.models.permissions.Profile;
 import fr.siamois.domain.models.permissions.ProfileConstants;
 import fr.siamois.domain.models.settings.InstitutionSettings;
 import fr.siamois.domain.models.vocabulary.FeedbackFieldConfig;
@@ -18,7 +19,9 @@ import fr.siamois.domain.services.vocabulary.FieldConfigurationService;
 import fr.siamois.domain.services.vocabulary.VocabularyService;
 import fr.siamois.dto.entity.ActionUnitDTO;
 import fr.siamois.dto.entity.InstitutionDTO;
+import fr.siamois.dto.entity.InstitutionMemberDTO;
 import fr.siamois.dto.entity.PersonDTO;
+import fr.siamois.dto.entity.ProfileDTO;
 import fr.siamois.infrastructure.database.repositories.institution.InstitutionRepository;
 import fr.siamois.infrastructure.database.repositories.permissions.PersonProfileAssignmentRepository;
 import fr.siamois.infrastructure.database.repositories.person.PersonRepository;
@@ -29,6 +32,7 @@ import fr.siamois.mapper.ProfileMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -300,26 +304,30 @@ class InstitutionServiceTest {
         PersonDTO p = new PersonDTO();
         p.setId(2L);
 
-        when(personProfileAssignmentService.addToManagers(instDto, p)).thenReturn(true);
+        Profile memberProfile = new Profile();
+        memberProfile.setCode(ProfileConstants.ORGANIZATION_MEMBER);
+        Profile managerProfile = new Profile();
+        managerProfile.setCode(ProfileConstants.ORGANIZATION_MANAGER);
+
+        ProfileDTO memberDTO = new ProfileDTO();
+        memberDTO.setCode(ProfileConstants.ORGANIZATION_MEMBER);
+        ProfileDTO managerProfileDTO = new ProfileDTO();
+        managerProfileDTO.setCode(ProfileConstants.ORGANIZATION_MANAGER);
+
+        when(profileService.createOrGetOrganizationMemberProfile(instDto)).thenReturn(memberProfile);
+        when(profileService.createOrGetOrganizationManagerProfile(instDto)).thenReturn(managerProfile);
+        when(profileMapper.convert(memberProfile)).thenReturn(memberDTO);
+        when(profileMapper.convert(managerProfile)).thenReturn(managerProfileDTO);
+        when(personProfileAssignmentService.addToInstitution(eq(instDto), eq(p), anyList()))
+                .thenReturn(new InstitutionMemberDTO());
 
         boolean added = institutionService.addToManagers(instDto, p);
 
         assertTrue(added);
-    }
 
-    @Test
-    void addToManagers_shouldNotAddManagerIfAlreadyExists() {
-        InstitutionDTO instDto = new InstitutionDTO();
-        instDto.setId(1L);
-
-        PersonDTO p = new PersonDTO();
-        p.setId(2L);
-
-        when(personProfileAssignmentService.addToManagers(instDto, p)).thenReturn(false);
-
-        boolean added = institutionService.addToManagers(instDto, p);
-
-        assertFalse(added);
+        ArgumentCaptor<List<ProfileDTO>> profilesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(personProfileAssignmentService).addToInstitution(eq(instDto), eq(p), profilesCaptor.capture());
+        assertThat(profilesCaptor.getValue()).containsExactlyInAnyOrder(memberDTO, managerProfileDTO);
     }
 
     @Test

--- a/src/test/java/fr/siamois/domain/services/InstitutionServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/InstitutionServiceTest.java
@@ -10,7 +10,6 @@ import fr.siamois.domain.models.exceptions.institution.InstitutionAlreadyExistEx
 import fr.siamois.domain.models.institution.Institution;
 import fr.siamois.domain.models.permissions.ProfileConstants;
 import fr.siamois.domain.models.settings.InstitutionSettings;
-import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.models.vocabulary.FeedbackFieldConfig;
 import fr.siamois.domain.models.vocabulary.Vocabulary;
 import fr.siamois.domain.services.permissions.PersonProfileAssignmentService;
@@ -180,29 +179,6 @@ class InstitutionServiceTest {
         when(vocabularyService.findOrCreateVocabularyOfUri(anyString())).thenThrow(new InvalidEndpointException("Invalid url"));
 
         assertThrows(InvalidEndpointException.class, () -> institutionService.createInstitution(institution1DTO, "invalid_url"));
-    }
-
-    @Test
-    void addUserToInstitution() throws FailedInstitutionSaveException {
-        Concept realRole = new Concept();
-        realRole.setId(1L);
-
-        institutionService.addUserToInstitution(manager, institution1, realRole);
-
-        verify(personRepository, times(1)).addPersonToInstitution(manager.getId(), institution1.getId(), realRole.getId());
-    }
-
-    @Test
-    void addUserToInstitution_throwsFailedInstitutionSaveException() {
-        Concept realRole = new Concept();
-        realRole.setId(1L);
-
-        doThrow(new RuntimeException("Error while adding person to institution"))
-                .when(personRepository)
-                .addPersonToInstitution(manager.getId(), institution1.getId(), realRole.getId());
-
-        assertThrows(FailedInstitutionSaveException.class, () ->
-                institutionService.addUserToInstitution(manager, institution1, realRole));
     }
 
     @Test

--- a/src/test/java/fr/siamois/domain/services/InstitutionServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/InstitutionServiceTest.java
@@ -482,35 +482,6 @@ class InstitutionServiceTest {
         assertThat(result).isFalse();
     }
 
-    @Test
-    void addPersonToActionManager_shouldAddManagerAndReturnTrue() {
-        InstitutionDTO institution = new InstitutionDTO();
-        institution.setId(1L);
-
-        PersonDTO personDto = new PersonDTO();
-        personDto.setId(1L);
-
-        when(personProfileAssignmentService.addToActionManagers(institution, personDto)).thenReturn(true);
-
-        boolean result = institutionService.addPersonToActionManager(institution, personDto);
-
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void addPersonToActionManager_shouldNotAddManagerIfAlreadyExists() {
-        InstitutionDTO institution = new InstitutionDTO();
-        institution.setId(1L);
-
-        PersonDTO personDto = new PersonDTO();
-        personDto.setId(1L);
-
-        when(personProfileAssignmentService.addToActionManagers(institution, personDto)).thenReturn(false);
-
-        boolean result = institutionService.addPersonToActionManager(institution, personDto);
-
-        assertThat(result).isFalse();
-    }
 
     @Test
     void addPersonAsMemberOfActionUnit_shouldAddMemberAndReturnTrue() {

--- a/src/test/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentServiceTest.java
@@ -93,19 +93,6 @@ class PersonProfileAssignmentServiceTest {
     }
 
     @Test
-    void addToActionManagers_ReturnsTrueWhenNotAlreadyAssigned() {
-        when(profileService.createOrGetOrganizationProjectManagerProfile(institutionDTO)).thenReturn(profile);
-        when(personMapper.invertConvert(personDTO)).thenReturn(person);
-        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(profile.getId(), person.getId()))
-                .thenReturn(Optional.empty());
-
-        boolean result = service.addToActionManagers(institutionDTO, personDTO);
-
-        assertTrue(result);
-        verify(personProfileAssignmentRepository, times(1)).save(any(PersonProfileAssignment.class));
-    }
-
-    @Test
     void addToProjectMembers_ReturnsTrueWhenNotAlreadyAssigned() {
         when(profileService.createOrGetProjectMemberProfile(actionUnitDTO)).thenReturn(profile);
         when(personMapper.invertConvert(personDTO)).thenReturn(person);

--- a/src/test/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/permissions/PersonProfileAssignmentServiceTest.java
@@ -11,6 +11,7 @@ import fr.siamois.mapper.ProfileMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -64,45 +66,103 @@ class PersonProfileAssignmentServiceTest {
 
         institutionDTO = new InstitutionDTO();
         actionUnitDTO = new ActionUnitDTO();
+        actionUnitDTO.setCreatedByInstitution(institutionDTO);
+    }
+
+    private Profile buildProfile(Long id, String code) {
+        Profile p = new Profile();
+        p.setId(id);
+        p.setCode(code);
+        return p;
+    }
+
+    private ProfileDTO buildProfileDTO(String code) {
+        ProfileDTO dto = new ProfileDTO();
+        dto.setCode(code);
+        return dto;
     }
 
     @Test
-    void addToManagers_ReturnsTrueWhenNotAlreadyAssigned() {
-        when(profileService.createOrGetOrganizationManagerProfile(institutionDTO)).thenReturn(profile);
+    void addToManagers_AssignsManagerAndMemberProfiles() {
+        Profile managerProfile = buildProfile(10L, ProfileConstants.ORGANIZATION_MANAGER);
+        Profile memberProfile = buildProfile(11L, ProfileConstants.ORGANIZATION_MEMBER);
+        ProfileDTO managerDTO = buildProfileDTO(ProfileConstants.ORGANIZATION_MANAGER);
+        ProfileDTO memberDTO = buildProfileDTO(ProfileConstants.ORGANIZATION_MEMBER);
+
+        when(profileService.createOrGetOrganizationManagerProfile(institutionDTO)).thenReturn(managerProfile);
+        when(profileService.createOrGetOrganizationMemberProfile(institutionDTO)).thenReturn(memberProfile);
+        when(profileMapper.convert(managerProfile)).thenReturn(managerDTO);
+        when(profileMapper.convert(memberProfile)).thenReturn(memberDTO);
+        when(profileMapper.invertConvert(managerDTO)).thenReturn(managerProfile);
+        when(profileMapper.invertConvert(memberDTO)).thenReturn(memberProfile);
         when(personMapper.invertConvert(personDTO)).thenReturn(person);
-        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(profile.getId(), person.getId()))
+        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(anyLong(), eq(person.getId())))
                 .thenReturn(Optional.empty());
 
         boolean result = service.addToManagers(institutionDTO, personDTO);
 
         assertTrue(result);
-        verify(personProfileAssignmentRepository, times(1)).save(any(PersonProfileAssignment.class));
+        verify(personProfileAssignmentRepository, times(2)).save(any(PersonProfileAssignment.class));
     }
 
     @Test
-    void addToManagers_ReturnsFalseWhenAlreadyAssigned() {
-        when(profileService.createOrGetOrganizationManagerProfile(institutionDTO)).thenReturn(profile);
+    void addToManagers_DoesNotSaveWhenAlreadyAssigned() {
+        Profile managerProfile = buildProfile(10L, ProfileConstants.ORGANIZATION_MANAGER);
+        Profile memberProfile = buildProfile(11L, ProfileConstants.ORGANIZATION_MEMBER);
+        ProfileDTO managerDTO = buildProfileDTO(ProfileConstants.ORGANIZATION_MANAGER);
+        ProfileDTO memberDTO = buildProfileDTO(ProfileConstants.ORGANIZATION_MEMBER);
+
+        when(profileService.createOrGetOrganizationManagerProfile(institutionDTO)).thenReturn(managerProfile);
+        when(profileService.createOrGetOrganizationMemberProfile(institutionDTO)).thenReturn(memberProfile);
+        when(profileMapper.convert(managerProfile)).thenReturn(managerDTO);
+        when(profileMapper.convert(memberProfile)).thenReturn(memberDTO);
+        when(profileMapper.invertConvert(managerDTO)).thenReturn(managerProfile);
+        when(profileMapper.invertConvert(memberDTO)).thenReturn(memberProfile);
         when(personMapper.invertConvert(personDTO)).thenReturn(person);
-        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(profile.getId(), person.getId()))
+        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(anyLong(), eq(person.getId())))
                 .thenReturn(Optional.of(new PersonProfileAssignment()));
 
         boolean result = service.addToManagers(institutionDTO, personDTO);
 
-        assertFalse(result);
+        assertTrue(result);
         verify(personProfileAssignmentRepository, never()).save(any());
     }
 
     @Test
     void addToProjectMembers_ReturnsTrueWhenNotAlreadyAssigned() {
+        Profile orgMemberProfile = buildProfile(50L, ProfileConstants.ORGANIZATION_MEMBER);
+
         when(profileService.createOrGetProjectMemberProfile(actionUnitDTO)).thenReturn(profile);
+        when(profileService.createOrGetOrganizationMemberProfile(institutionDTO)).thenReturn(orgMemberProfile);
         when(personMapper.invertConvert(personDTO)).thenReturn(person);
-        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(profile.getId(), person.getId()))
+        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(anyLong(), eq(person.getId())))
                 .thenReturn(Optional.empty());
 
         boolean result = service.addToProjectMembers(actionUnitDTO, personDTO);
 
         assertTrue(result);
-        verify(personProfileAssignmentRepository, times(1)).save(any(PersonProfileAssignment.class));
+        // Une assignation pour le profil membre de projet + une pour le profil membre d'organisation
+        verify(personProfileAssignmentRepository, times(2)).save(any(PersonProfileAssignment.class));
+    }
+
+    @Test
+    void addToProjectMembers_AssignsOrganizationMemberProfileOfProjectInstitution() {
+        Profile orgMemberProfile = buildProfile(50L, ProfileConstants.ORGANIZATION_MEMBER);
+
+        when(profileService.createOrGetProjectMemberProfile(actionUnitDTO)).thenReturn(profile);
+        when(profileService.createOrGetOrganizationMemberProfile(institutionDTO)).thenReturn(orgMemberProfile);
+        when(personMapper.invertConvert(personDTO)).thenReturn(person);
+        when(personProfileAssignmentRepository.findByProfileIdAndPersonId(anyLong(), eq(person.getId())))
+                .thenReturn(Optional.empty());
+
+        service.addToProjectMembers(actionUnitDTO, personDTO);
+
+        verify(profileService).createOrGetOrganizationMemberProfile(institutionDTO);
+        ArgumentCaptor<PersonProfileAssignment> assignmentCaptor = ArgumentCaptor.forClass(PersonProfileAssignment.class);
+        verify(personProfileAssignmentRepository, times(2)).save(assignmentCaptor.capture());
+        assertThat(assignmentCaptor.getAllValues())
+                .extracting(PersonProfileAssignment::getProfile)
+                .containsExactlyInAnyOrder(profile, orgMemberProfile);
     }
 
     @Test
@@ -110,12 +170,14 @@ class PersonProfileAssignmentServiceTest {
         List<ProfileDTO> profiles = new ArrayList<>();
         profiles.add(profileDTO); // Ne contient pas ORGANIZATION_MEMBER
 
-        Profile memberProfile = new Profile();
-        memberProfile.setId(99L);
+        Profile memberProfile = buildProfile(99L, ProfileConstants.ORGANIZATION_MEMBER);
+        ProfileDTO memberDTO = buildProfileDTO(ProfileConstants.ORGANIZATION_MEMBER);
 
         when(personMapper.invertConvert(personDTO)).thenReturn(person);
         when(profileService.createOrGetOrganizationMemberProfile(institutionDTO)).thenReturn(memberProfile);
         when(profileMapper.invertConvert(profileDTO)).thenReturn(profile);
+        when(profileMapper.convert(memberProfile)).thenReturn(memberDTO);
+        when(profileMapper.convert(profile)).thenReturn(profileDTO);
 
         // Simuler qu'aucune assignation n'existe déjà
         when(personProfileAssignmentRepository.findByProfileIdAndPersonId(anyLong(), eq(person.getId())))
@@ -125,7 +187,8 @@ class PersonProfileAssignmentServiceTest {
 
         assertNotNull(result);
         assertEquals(personDTO, result.getPerson());
-        assertEquals(profiles, result.getProfiles());
+        // Le profil membre ajouté par défaut fait désormais partie des profils retournés
+        assertThat(result.getProfiles()).containsExactlyInAnyOrder(profileDTO, memberDTO);
 
         // Vérifie que createOrGetOrganizationMemberProfile a été appelé car le code n'y était pas
         verify(profileService, times(1)).createOrGetOrganizationMemberProfile(institutionDTO);
@@ -164,8 +227,11 @@ class PersonProfileAssignmentServiceTest {
         Profile memberProfile = new Profile();
         memberProfile.setId(88L);
 
+        Profile orgMemberProfile = buildProfile(50L, ProfileConstants.ORGANIZATION_MEMBER);
+
         when(personMapper.invertConvert(personDTO)).thenReturn(person);
         when(profileService.createOrGetProjectMemberProfile(actionUnitDTO)).thenReturn(memberProfile);
+        when(profileService.createOrGetOrganizationMemberProfile(institutionDTO)).thenReturn(orgMemberProfile);
         when(profileMapper.invertConvert(profileDTO)).thenReturn(profile);
         when(personProfileAssignmentRepository.findByProfileIdAndPersonId(anyLong(), eq(person.getId())))
                 .thenReturn(Optional.empty());
@@ -176,7 +242,8 @@ class PersonProfileAssignmentServiceTest {
         assertEquals(personDTO, result.getPerson());
 
         verify(profileService, times(1)).createOrGetProjectMemberProfile(actionUnitDTO);
-        verify(personProfileAssignmentRepository, times(2)).save(any(PersonProfileAssignment.class));
+        // Membre de projet par défaut + membre d'organisation + le profil passé en liste
+        verify(personProfileAssignmentRepository, times(3)).save(any(PersonProfileAssignment.class));
     }
 
     @Test


### PR DESCRIPTION
# Why this PR ?
1. A project member must be a member of the parent organization.
2. The organization manager must be a member of the organization.
3. Some profiles do not appear in the list.
4. The roles screen does not display only the roles within its scope.

# What changed in this PR ?
1. When a user is added to a project, they are added as a “project member” and a member of the organization, even if the “project member” role is not selected. When a “project manager” creates a project, they are added as the project owner and a project member
2. When the superadmin creates an organization, they become the organization's manager and a member of the organization
3. Profiles associated with an organization or a project are created at the same time as the organization or project.
4. The error in the JPQL query for the organizations scope has been fixed.