### PR TITLE
Add autocomplete method for related concepts

### DIFF
--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -304,7 +304,7 @@ public class FieldConfigurationService {
      * @param info      the user information containing institution and user details
      * @param fieldCode the field code for which to fetch autocomplete suggestions
      * @param input     the input string to match against concept labels. Can be null or empty.
-     * @return a list of matching ConceptLabel objects
+     * @return a list of matching ConceptAutocompleteDTO objects
      * @throws NoConfigForFieldException if no configuration is found for the field code
      */
     @NonNull
@@ -312,6 +312,19 @@ public class FieldConfigurationService {
     public List<ConceptAutocompleteDTO> fetchAutocomplete(@NonNull UserInfo info, @NonNull String fieldCode, @Nullable String input) throws NoConfigForFieldException {
         ConceptFieldConfig config = findConfigurationForFieldCode(info, fieldCode);
         return autocompleteRepository.findMatchingConceptsFor(config.getConcept(), info.getLang(), input, LIMIT_RESULTS);
+    }
+
+    /**
+     * Fetches autocomplete suggestions depending on the base value.
+     * This autocompletion is used when the field is dependant of the value of another field.
+     * In that case, the autocompletion values are the related concepts of the selected previous value.
+     *
+     * @param info      the user information containing institution and user details
+     * @param baseValue the concept as the value of the field from which the current field is dependant of
+     * @param input     the input string to match against concept labels. Can be null or empty.
+     */
+    public List<ConceptAutocompleteDTO> fetchAutocompleteRelated(@NonNull UserInfo info, @NonNull Concept baseValue, @Nullable String input) {
+        return autocompleteRepository.findMatchingConceptsFromRelatedFor(baseValue, info.getLang(), input, LIMIT_RESULTS);
     }
 
     public int resultLimit() {

--- a/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/AutocompleteRepository.java
+++ b/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/AutocompleteRepository.java
@@ -97,11 +97,39 @@ public class AutocompleteRepository {
                                                                 @NonNull String lang,
                                                                 @Nullable String input,
                                                                 int limit) {
+        return executeAutocomplete("SELECT ca.* FROM concept_autocomplete(?, ?, ?, ?) ca", concept, lang, input, limit);
+    }
+
+    /**
+     * Find matching concepts among the concepts related to the given concept, in the specified language,
+     * input string and limit. This method calls the database function concept_autocomplete_related.
+     *
+     * @param baseValue    The concept whose related concepts are the autocomplete candidates
+     * @param lang         The language code to filter results
+     * @param input        The input string to match against concept labels
+     * @param limitResults The maximum number of results to return
+     * @return A list of ConceptAutocompleteDTO containing matching related concepts
+     */
+    @NonNull
+    @ExecutionTimeLogger
+    public List<ConceptAutocompleteDTO> findMatchingConceptsFromRelatedFor(@NonNull Concept baseValue,
+                                                                           @NonNull String lang,
+                                                                           @Nullable String input,
+                                                                           int limitResults) {
+        return executeAutocomplete("SELECT ca.* FROM concept_autocomplete_related(?, ?, ?, ?) ca", baseValue, lang, input, limitResults);
+    }
+
+    @NonNull
+    private List<ConceptAutocompleteDTO> executeAutocomplete(@NonNull String query,
+                                                             @NonNull Concept concept,
+                                                             @NonNull String lang,
+                                                             @Nullable String input,
+                                                             int limit) {
         List<ConceptAutocompleteDTO> results = new ArrayList<>();
 
         try (Connection connection = dataSource.getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT ca.* FROM concept_autocomplete(?, ?, ?, ?) ca")) {
-            log.trace("Executing concept autocomplete with concept id {}, lang {}, input '{}', limit {}", concept.getId(), lang, input, limit);
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            log.trace("Executing '{}' with concept id {}, lang {}, input '{}', limit {}", query, concept.getId(), lang, input, limit);
             statement.setLong(1, concept.getId());
             statement.setString(2, lang);
             statement.setString(3, input != null ? input : "");
@@ -112,7 +140,6 @@ public class AutocompleteRepository {
             log.error("Error while fetching autocomplete results for concept id {}: {}", concept.getId(), e.getMessage(), e);
             return List.of();
         }
-
     }
 
     private List<ConceptAutocompleteDTO> processResultSet(@NonNull Concept concept, @NonNull String lang, PreparedStatement statement, List<ConceptAutocompleteDTO> results) {
@@ -153,5 +180,4 @@ public class AutocompleteRepository {
         if (text == null) return "";
         return text.length() > DESCRIPTION_TRUNCATE_LENGTH ? text.substring(0, DESCRIPTION_TRUNCATE_LENGTH) + "..." : text;
     }
-
 }

--- a/src/main/resources/pgplsql/concept_autocomplete.sql
+++ b/src/main/resources/pgplsql/concept_autocomplete.sql
@@ -1,4 +1,6 @@
 DROP FUNCTION IF EXISTS concept_autocomplete;
+DROP FUNCTION IF EXISTS concept_autocomplete_related;
+DROP FUNCTION IF EXISTS concept_autocomplete_search;
 DROP FUNCTION IF EXISTS concept_autocomplete_get_definition;
 DROP FUNCTION IF EXISTS concept_autocomplete_get_hierarchy;
 DROP FUNCTION IF EXISTS concept_autocomplete_get_alt_labels;
@@ -45,7 +47,7 @@ BEGIN
     INTO v_pref_label
     FROM concept_label cl
     WHERE cl.fk_concept_id = p_concept_id
-      AND cl.fk_field_parent_concept_id = p_field_concept_id
+      AND cl.fk_field_parent_concept_id IS NOT DISTINCT FROM p_field_concept_id
       AND cl.lang_code = p_langcode
       AND cl.label_type = 0
     LIMIT 1;
@@ -55,7 +57,7 @@ BEGIN
         INTO v_pref_label
         FROM concept_label cl
         WHERE cl.fk_concept_id = p_concept_id
-          AND cl.fk_field_parent_concept_id = p_field_concept_id
+          AND cl.fk_field_parent_concept_id IS NOT DISTINCT FROM p_field_concept_id
           AND cl.label_type = 0
         LIMIT 1;
     END IF;
@@ -65,7 +67,7 @@ BEGIN
         INTO v_pref_label
         FROM concept_label cl
         WHERE cl.fk_concept_id = p_concept_id
-          AND cl.fk_field_parent_concept_id = p_field_concept_id
+          AND cl.fk_field_parent_concept_id IS NOT DISTINCT FROM p_field_concept_id
         LIMIT 1;
     END IF;
 
@@ -93,7 +95,7 @@ BEGIN
     INTO v_alt_labels
     FROM concept_label cl
     WHERE cl.fk_concept_id = p_concept_id
-      AND cl.fk_field_parent_concept_id = p_field_concept_id
+      AND cl.fk_field_parent_concept_id IS NOT DISTINCT FROM p_field_concept_id
       AND cl.lang_code = p_langcode
       AND cl.label_type = 1;
 
@@ -158,7 +160,72 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Main autocomplete function
+-- Core autocomplete query, shared by every autocomplete entry point.
+-- Exactly one of p_field_concept_id / p_related_of_concept_id is expected to be filled:
+--   * p_field_concept_id      : restrict to the concepts imported in the context of that field concept
+--   * p_related_of_concept_id : restrict to the concepts related (concept_related) to that concept
+-- p_input NULL or blank means "no text filter", the results are then only ordered alphabetically.
+CREATE OR REPLACE FUNCTION concept_autocomplete_search(
+    p_field_concept_id BIGINT,
+    p_related_of_concept_id BIGINT,
+    p_langcode VARCHAR(3),
+    p_input TEXT,
+    p_limit INT
+)
+    RETURNS SETOF concept_autocomplete_record AS
+$$
+BEGIN
+    -- The matching labels are selected and limited first so the aggregation functions below
+    -- (alt labels, definition, hierarchy) are only evaluated for the rows actually returned.
+    RETURN QUERY
+        WITH matching_labels AS (SELECT cl.concept_label_id,
+                                        cl.label,
+                                        cl.fk_concept_id,
+                                        cl.fk_field_parent_concept_id
+                                 FROM concept_label cl
+                                          JOIN concept c ON cl.fk_concept_id = c.concept_id
+                                 WHERE cl.lang_code = p_langcode
+                                   AND cl.label_type = 0
+                                   AND NOT c.is_deleted
+                                   AND (p_field_concept_id IS NULL OR
+                                        cl.fk_field_parent_concept_id = p_field_concept_id)
+                                   AND (p_related_of_concept_id IS NULL OR EXISTS (SELECT 1
+                                                                                   FROM concept_related cr
+                                                                                   WHERE cr.fk_concept_id = p_related_of_concept_id
+                                                                                     AND cr.fk_related_concept_id = c.concept_id))
+                                   AND (p_input IS NULL OR trim(p_input) = '' OR
+                                        unaccent(cl.label) ILIKE unaccent('%' || p_input || '%'))
+                                 ORDER BY cl.label -- Sort by label in alphabetical order
+                                 LIMIT p_limit)
+        SELECT c.concept_id,
+               c.external_id,
+
+               c2.concept_id,
+               c2.external_id,
+
+               v.vocabulary_id,
+               v.base_uri,
+               v.external_id,
+
+               vt.vocabulary_type_id,
+               vt.label,
+
+               ml.concept_label_id,
+               ml.label,
+
+               concept_autocomplete_get_alt_labels(c.concept_id, ml.fk_field_parent_concept_id, p_langcode),
+               concept_autocomplete_get_definition(c.concept_id, p_langcode),
+               concept_autocomplete_get_hierarchy(c.concept_id, ml.fk_field_parent_concept_id, p_langcode)
+        FROM matching_labels ml
+                 JOIN concept c ON ml.fk_concept_id = c.concept_id
+                 LEFT JOIN concept c2 ON c2.concept_id = ml.fk_field_parent_concept_id
+                 JOIN vocabulary v ON c.fk_vocabulary_id = v.vocabulary_id
+                 JOIN vocabulary_type vt ON v.fk_type_id = vt.vocabulary_type_id
+        ORDER BY ml.label;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Autocomplete on every concept configured for the given field concept
 CREATE OR REPLACE FUNCTION concept_autocomplete(
     p_field_concept_id BIGINT,
     p_langcode VARCHAR(3),
@@ -167,79 +234,22 @@ CREATE OR REPLACE FUNCTION concept_autocomplete(
 )
     RETURNS SETOF concept_autocomplete_record AS
 $$
-DECLARE
 BEGIN
+    RETURN QUERY SELECT * FROM concept_autocomplete_search(p_field_concept_id, NULL, p_langcode, p_input, p_limit);
+END;
+$$ LANGUAGE plpgsql;
 
-    if p_input IS NULL OR trim(p_input) = '' THEN
-        -- Cas quand input est NULL ou vide
-        RETURN QUERY
-            SELECT c.concept_id,
-                   c.external_id,
-
-                   c2.concept_id,
-                   c2.external_id,
-
-                   v.vocabulary_id,
-                   v.base_uri,
-                   v.external_id,
-
-                   vt.vocabulary_type_id,
-                   vt.label,
-
-                   cl.concept_label_id,
-                   cl.label,
-
-                   concept_autocomplete_get_alt_labels(c.concept_id, p_field_concept_id, p_langcode),
-                   concept_autocomplete_get_definition(c.concept_id, p_langcode),
-                   concept_autocomplete_get_hierarchy(c.concept_id, p_field_concept_id, p_langcode)
-            FROM concept_label cl
-                     JOIN concept c ON cl.fk_concept_id = c.concept_id
-                     JOIN concept c2 ON c2.concept_id = p_field_concept_id
-                     JOIN vocabulary v ON c.fk_vocabulary_id = v.vocabulary_id
-                     JOIN vocabulary_type vt ON v.fk_type_id = vt.vocabulary_type_id
-            WHERE cl.fk_field_parent_concept_id = p_field_concept_id
-              AND cl.lang_code = p_langcode
-              AND NOT c.is_deleted
-              AND cl.label_type = 0
-            ORDER BY cl.label  -- Sort by label in alphabetical order
-            LIMIT p_limit;
-    ELSE
-
-        -- Cas quand input n'est pas vide
-        RETURN QUERY
-            SELECT c.concept_id,
-                   c.external_id,
-
-                   c2.concept_id,
-                   c2.external_id,
-
-                   v.vocabulary_id,
-                   v.base_uri,
-                   v.external_id,
-
-                   vt.vocabulary_type_id,
-                   vt.label,
-
-                   cl.concept_label_id,
-                   cl.label,
-
-                   concept_autocomplete_get_alt_labels(c.concept_id, p_field_concept_id, p_langcode),
-                   concept_autocomplete_get_definition(c.concept_id, p_langcode),
-                   concept_autocomplete_get_hierarchy(c.concept_id, p_field_concept_id, p_langcode)
-            FROM concept_label cl
-                     JOIN concept c ON cl.fk_concept_id = c.concept_id
-                     JOIN concept c2 ON c2.concept_id = p_field_concept_id
-                     JOIN vocabulary v ON c.fk_vocabulary_id = v.vocabulary_id
-                     JOIN vocabulary_type vt ON v.fk_type_id = vt.vocabulary_type_id
-            WHERE cl.fk_field_parent_concept_id = p_field_concept_id
-              AND cl.lang_code = p_langcode
-              AND NOT c.is_deleted
-              AND unaccent(cl.label) ILIKE unaccent('%' || p_input || '%')
-              AND cl.label_type = 0
-            ORDER BY cl.label  -- Sort by label in alphabetical order
-            LIMIT p_limit;
-
-    END IF;
-
+-- Autocomplete restricted to the concepts related to p_base_concept_id.
+-- Used when a field value depends on the value selected in another field.
+CREATE OR REPLACE FUNCTION concept_autocomplete_related(
+    p_base_concept_id BIGINT,
+    p_langcode VARCHAR(3),
+    p_input TEXT,
+    p_limit INT
+)
+    RETURNS SETOF concept_autocomplete_record AS
+$$
+BEGIN
+    RETURN QUERY SELECT * FROM concept_autocomplete_search(NULL, p_base_concept_id, p_langcode, p_input, p_limit);
 END;
 $$ LANGUAGE plpgsql;

--- a/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
@@ -339,6 +339,26 @@ class FieldConfigurationServiceTest {
     }
 
     @Test
+    void fetchAutocompleteRelated_shouldReturnRelatedConceptsOfBaseValue() {
+        String query = "test query";
+
+        Concept baseValue = new Concept();
+        baseValue.setVocabulary(vocabulary);
+        baseValue.setExternalId("12");
+
+        List<ConceptAutocompleteDTO> expectedResults = List.of(
+                new ConceptAutocompleteDTO(new ConceptDTO(), "Concept 100", "100"),
+                new ConceptAutocompleteDTO(new ConceptDTO(), "Concept 101", "101")
+        );
+        when(autocompleteRepository.findMatchingConceptsFromRelatedFor(baseValue, "fr", query, FieldConfigurationService.LIMIT_RESULTS))
+                .thenReturn(expectedResults);
+
+        List<ConceptAutocompleteDTO> results = service.fetchAutocompleteRelated(userInfo, baseValue, query);
+
+        assertThat(results).isEqualTo(expectedResults);
+    }
+
+    @Test
     void resultLimit_shoudReturnCurrentResultLimit() {
         assertThat(service.resultLimit()).isEqualTo(FieldConfigurationService.LIMIT_RESULTS);
     }

--- a/src/test/java/fr/siamois/infrastructure/database/repositories/vocabulary/AutocompleteRepositoryTest.java
+++ b/src/test/java/fr/siamois/infrastructure/database/repositories/vocabulary/AutocompleteRepositoryTest.java
@@ -5,6 +5,7 @@ import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.infrastructure.database.repositories.vocabulary.dto.ConceptAutocompleteDTO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -125,6 +126,80 @@ class AutocompleteRepositoryTest {
         ConceptAutocompleteDTO dto = results.get(0);
         assertEquals("", dto.getDefinition(), "Null definition should be converted to empty string");
         assertEquals(0, dto.getAltLabels().size(), "Alt labels list should be empty");
+    }
+
+    @Test
+    void shouldQueryRelatedFunctionAndBindBaseConcept() throws Exception {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getLong("vocabulary_type_id")).thenReturn(1L);
+        when(resultSet.getString("vocabulary_type_label")).thenReturn("Type");
+        when(resultSet.getLong("vocabulary_id")).thenReturn(2L);
+        when(resultSet.getString("vocabulary_base_uri")).thenReturn("base");
+        when(resultSet.getString("vocabulary_external_id")).thenReturn("ext");
+        when(resultSet.getLong("concept_id")).thenReturn(3L);
+        when(resultSet.getString("concept_external_id")).thenReturn("extC");
+        // related concepts are imported without field context: the parent concept can be absent
+        when(resultSet.getLong("parent_concept_id")).thenReturn(0L);
+        when(resultSet.getString("parent_concept_external_id")).thenReturn(null);
+        when(resultSet.getLong("concept_label_id")).thenReturn(5L);
+        when(resultSet.getString("concept_label_label")).thenReturn("relatedLabel");
+        when(resultSet.getString("data_aggregated_alt_labels")).thenReturn(null);
+        when(resultSet.getString("data_definition")).thenReturn("def");
+        when(resultSet.getString("data_hierarchy_str")).thenReturn(null);
+
+        Concept baseValue = new Concept();
+        baseValue.setId(155L);
+
+        List<ConceptAutocompleteDTO> results = autocompleteRepository.findMatchingConceptsFromRelatedFor(baseValue, "fr", "blo", 10);
+
+        assertEquals(1, results.size());
+        assertEquals("relatedLabel", results.get(0).getOriginalPrefLabel());
+
+        // the related search must hit the dedicated DB function, not the field-based one
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(connection).prepareStatement(queryCaptor.capture());
+        assertTrue(queryCaptor.getValue().contains("concept_autocomplete_related("),
+                "Expected the query to call concept_autocomplete_related, but was: " + queryCaptor.getValue());
+
+        verify(statement).setLong(1, 155L);
+        verify(statement).setString(2, "fr");
+        verify(statement).setString(3, "blo");
+        verify(statement).setInt(4, 10);
+    }
+
+    @Test
+    void shouldBindEmptyStringWhenRelatedInputIsNull() throws Exception {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
+
+        Concept baseValue = new Concept();
+        baseValue.setId(155L);
+
+        List<ConceptAutocompleteDTO> results = autocompleteRepository.findMatchingConceptsFromRelatedFor(baseValue, "fr", null, 10);
+
+        assertEquals(0, results.size());
+        verify(statement).setString(3, "");
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenRelatedStatementThrows() throws Exception {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(statement);
+        when(statement.executeQuery()).thenThrow(new SQLException("boom"));
+
+        Concept baseValue = new Concept();
+        baseValue.setId(155L);
+
+        List<ConceptAutocompleteDTO> results = autocompleteRepository.findMatchingConceptsFromRelatedFor(baseValue, "fr", "in", 10);
+
+        assertNotNull(results);
+        assertEquals(0, results.size());
     }
 
     @Test


### PR DESCRIPTION
# Why this PR ?
The autocomplete method is required for the new conditional fields

# What changed ?
- Added `FieldConfigurationService#fetchAutocompleteRelated` which calls `concept_autocomplete_related` pg/PLSQL procedure
- Refactor `concept_autocomplete.sql` procedures