### PR TITLE
Add thesaurus configuration at Action Unit level

### DIFF
--- a/src/main/java/fr/siamois/domain/models/settings/ConceptFieldConfig.java
+++ b/src/main/java/fr/siamois/domain/models/settings/ConceptFieldConfig.java
@@ -1,5 +1,6 @@
 package fr.siamois.domain.models.settings;
 
+import fr.siamois.domain.models.actionunit.ActionUnit;
 import fr.siamois.domain.models.institution.Institution;
 import fr.siamois.domain.models.vocabulary.Concept;
 import jakarta.persistence.*;
@@ -7,6 +8,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.lang.Nullable;
 
 import java.util.Objects;
 
@@ -27,6 +29,11 @@ public class ConceptFieldConfig {
     @JoinColumn(name = "fk_institution_id", nullable = false)
     private Institution institution;
 
+    @Nullable
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_action_unit_id")
+    private ActionUnit actionUnit;
+
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "fk_concept_id", nullable = false)
@@ -44,11 +51,12 @@ public class ConceptFieldConfig {
         if (!(o instanceof ConceptFieldConfig that)) return false;
         return Objects.equals(institution, that.institution)
                 && Objects.equals(concept, that.concept)
-                && Objects.equals(fieldCode, that.fieldCode);
+                && Objects.equals(fieldCode, that.fieldCode)
+                && Objects.equals(actionUnit, that.actionUnit);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(institution, concept, fieldCode);
+        return Objects.hash(institution, concept, fieldCode, actionUnit);
     }
 }

--- a/src/main/java/fr/siamois/domain/models/settings/ConceptFieldConfig.java
+++ b/src/main/java/fr/siamois/domain/models/settings/ConceptFieldConfig.java
@@ -1,10 +1,10 @@
 package fr.siamois.domain.models.settings;
 
-import fr.siamois.domain.models.auth.Person;
 import fr.siamois.domain.models.institution.Institution;
 import fr.siamois.domain.models.vocabulary.Concept;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +14,7 @@ import java.util.Objects;
 @Setter
 @Entity
 @Table(name = "concept_field_config")
+@Data
 public class ConceptFieldConfig {
 
     @Id
@@ -25,10 +26,6 @@ public class ConceptFieldConfig {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "fk_institution_id", nullable = false)
     private Institution institution;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "fk_user_id")
-    private Person user;
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -46,13 +43,12 @@ public class ConceptFieldConfig {
     public boolean equals(Object o) {
         if (!(o instanceof ConceptFieldConfig that)) return false;
         return Objects.equals(institution, that.institution)
-                && Objects.equals(user, that.user)
                 && Objects.equals(concept, that.concept)
                 && Objects.equals(fieldCode, that.fieldCode);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(institution, user, concept, fieldCode);
+        return Objects.hash(institution, concept, fieldCode);
     }
 }

--- a/src/main/java/fr/siamois/domain/models/vocabulary/FeedbackFieldConfig.java
+++ b/src/main/java/fr/siamois/domain/models/vocabulary/FeedbackFieldConfig.java
@@ -4,23 +4,7 @@ import fr.siamois.infrastructure.api.dto.FullInfoDTO;
 
 import java.util.List;
 
-public class FeedbackFieldConfig {
-
-    private final List<String> missingFieldCode;
-    private final List<FullInfoDTO> conceptWithValidFieldCode;
-
-    public FeedbackFieldConfig(List<String> missingFieldCode, List<FullInfoDTO> conceptWithValidFieldCode) {
-        this.missingFieldCode = missingFieldCode;
-        this.conceptWithValidFieldCode = conceptWithValidFieldCode;
-    }
-
-    public List<String> missingFieldCode() {
-        return missingFieldCode;
-    }
-
-    public List<FullInfoDTO> conceptWithValidFieldCode() {
-        return conceptWithValidFieldCode;
-    }
+public record FeedbackFieldConfig(List<String> missingFieldCode, List<FullInfoDTO> conceptWithValidFieldCode) {
 
     public boolean isWrongConfig() {
         return !missingFieldCode.isEmpty();

--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -2,7 +2,6 @@ package fr.siamois.domain.services.vocabulary;
 
 import fr.siamois.annotations.ExecutionTimeLogger;
 import fr.siamois.domain.models.UserInfo;
-import fr.siamois.domain.models.auth.Person;
 import fr.siamois.domain.models.exceptions.ErrorProcessingExpansionException;
 import fr.siamois.domain.models.exceptions.api.NotSiamoisThesaurusException;
 import fr.siamois.domain.models.exceptions.vocabulary.NoConfigForFieldException;
@@ -14,7 +13,6 @@ import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.models.vocabulary.FeedbackFieldConfig;
 import fr.siamois.domain.models.vocabulary.Vocabulary;
 import fr.siamois.dto.entity.InstitutionDTO;
-import fr.siamois.dto.entity.PersonDTO;
 import fr.siamois.infrastructure.api.ConceptApi;
 import fr.siamois.infrastructure.api.dto.ConceptBranchDTO;
 import fr.siamois.infrastructure.api.dto.FullInfoDTO;
@@ -88,7 +86,7 @@ public class FieldConfigurationService {
      * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
      */
     public Optional<FeedbackFieldConfig> setupFieldConfigurationForInstitution(InstitutionDTO institution, Vocabulary vocabulary, ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        return setupFieldConfiguration(institution, null, vocabulary, progressWrapper);
+        return setupFieldConfiguration(institution, vocabulary, progressWrapper);
     }
 
     /**
@@ -117,7 +115,7 @@ public class FieldConfigurationService {
      */
     @NonNull
     public Optional<FeedbackFieldConfig> setupFieldConfigurationForInstitution(@NonNull InstitutionDTO institution, @NonNull Vocabulary vocabulary) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        return setupFieldConfiguration(institution, null, vocabulary, new ProgressWrapper());
+        return setupFieldConfiguration(institution, vocabulary, new ProgressWrapper());
     }
 
     private FeedbackFieldConfig createConfigOfThesaurus(ConceptBranchDTO conceptBranchDTO) {
@@ -142,36 +140,7 @@ public class FieldConfigurationService {
         return new FeedbackFieldConfig(missingFieldCode, validConcept);
     }
 
-    /**
-     * Sets up the field configuration for a user based on the vocabulary.
-     *
-     * @param info       the user information containing institution and user details
-     * @param vocabulary the vocabulary to use for configuration
-     * @return an Optional containing GlobalFieldConfig if the configuration is wrong, otherwise empty
-     * @throws NotSiamoisThesaurusException      if the vocabulary is not a Siamois thesaurus
-     * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
-     */
-    @NonNull
-    public Optional<FeedbackFieldConfig> setupFieldConfigurationForUser(@NonNull UserInfo info, @NonNull Vocabulary vocabulary) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        return setupFieldConfiguration(info.getInstitution(), info.getUser(), vocabulary, new ProgressWrapper());
-    }
-
-    /**
-     * Sets up the field configuration for a user based on the vocabulary.
-     *
-     * @param info            the user information containing institution and user details
-     * @param vocabulary      the vocabulary to use for configuration
-     * @param progressWrapper the progress wrapper to track progress
-     * @throws NotSiamoisThesaurusException      if the vocabulary is not a Siamois thesaurus
-     * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
-     */
-    public void setupFieldConfigurationForUser(@NonNull UserInfo info, @NonNull Vocabulary vocabulary, ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        setupFieldConfiguration(info.getInstitution(), info.getUser(), vocabulary, progressWrapper);
-    }
-
-
     private Optional<FeedbackFieldConfig> setupFieldConfiguration(@NonNull InstitutionDTO institutionDTO,
-                                                                  @Nullable PersonDTO userDTO,
                                                                   @NonNull Vocabulary vocabulary,
                                                                   @NonNull ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
         ConceptBranchDTO conceptBranchDTO = conceptApi.fetchFieldsBranch(vocabulary);
@@ -187,18 +156,12 @@ public class FieldConfigurationService {
             ConceptFieldConfig fieldConfig;
             Optional<ConceptFieldConfig> optConfig;
 
-            if (userDTO == null) {
-                optConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(institutionDTO.getId(), fieldCode);
-            } else {
-                optConfig = conceptFieldConfigRepository.findOneByFieldCodeForUser(userDTO.getId(), institutionDTO.getId(), fieldCode);
-            }
+            optConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(institutionDTO.getId(), fieldCode);
 
             if (optConfig.isEmpty()) {
                 Institution institution = institutionMapper.invertConvert(institutionDTO);
-                Person user = personMapper.invertConvert(userDTO);
                 fieldConfig = new ConceptFieldConfig();
                 fieldConfig.setInstitution(institution);
-                fieldConfig.setUser(user);
                 fieldConfig.setFieldCode(fieldCode);
                 fieldConfig.setConcept(concept);
                 fieldConfig = conceptFieldConfigRepository.save(fieldConfig);

--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -305,9 +305,7 @@ public class FieldConfigurationService {
     @Transactional(readOnly = true)
     public Map<String, List<ConceptAutocompleteDTO>> fetchAllConfiguredVocabularies(@NonNull UserInfo info) {
         Long institutionId = info.getInstitution().getId();
-        Long personId = info.getUser().getId();
-        List<String> fieldCodes = conceptFieldConfigRepository.findDistinctFieldCodesForInstitutionAndUser(
-                institutionId, personId);
+        List<String> fieldCodes = conceptFieldConfigRepository.findDistinctFieldCodesForInstitution(institutionId);
         Map<String, List<ConceptAutocompleteDTO>> out = new LinkedHashMap<>();
         for (String fieldCode : fieldCodes) {
             try {

--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -12,6 +12,7 @@ import fr.siamois.domain.models.spatialunit.SpatialUnit;
 import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.models.vocabulary.FeedbackFieldConfig;
 import fr.siamois.domain.models.vocabulary.Vocabulary;
+import fr.siamois.dto.entity.ActionUnitDTO;
 import fr.siamois.dto.entity.InstitutionDTO;
 import fr.siamois.infrastructure.api.ConceptApi;
 import fr.siamois.infrastructure.api.dto.ConceptBranchDTO;
@@ -257,15 +258,23 @@ public class FieldConfigurationService {
         return institutionConfig.get();
     }
 
-    /**
-     * Fetches autocomplete suggestions for a given field code and input string.
-     *
-     * @param info      the user information containing institution and user details
-     * @param fieldCode the field code for which to fetch autocomplete suggestions
-     * @param input     the input string to match against concept labels. Can be null or empty.
-     * @return a list of matching ConceptAutocompleteDTO objects
-     * @throws NoConfigForFieldException if no configuration is found for the field code
-     */
+    public ConceptFieldConfig findConfigurationForFieldCode(@NonNull UserInfo info, @NonNull String fieldCode, @NonNull ActionUnitDTO actionUnitDTO) throws NoConfigForFieldException {
+        Optional<ConceptFieldConfig> projectConfig = conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(fieldCode, actionUnitDTO.getId());
+        if (projectConfig.isEmpty()) {
+            return findConfigurationForFieldCode(info, fieldCode);
+        }
+        return projectConfig.get();
+    }
+
+        /**
+         * Fetches autocomplete suggestions for a given field code and input string.
+         *
+         * @param info      the user information containing institution and user details
+         * @param fieldCode the field code for which to fetch autocomplete suggestions
+         * @param input     the input string to match against concept labels. Can be null or empty.
+         * @return a list of matching ConceptAutocompleteDTO objects
+         * @throws NoConfigForFieldException if no configuration is found for the field code
+         */
     @NonNull
     @ExecutionTimeLogger
     public List<ConceptAutocompleteDTO> fetchAutocomplete(@NonNull UserInfo info, @NonNull String fieldCode, @Nullable String input) throws NoConfigForFieldException {

--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -21,6 +21,7 @@ import fr.siamois.infrastructure.database.repositories.vocabulary.AutocompleteRe
 import fr.siamois.infrastructure.database.repositories.vocabulary.ConceptFieldConfigRepository;
 import fr.siamois.infrastructure.database.repositories.vocabulary.ConceptRepository;
 import fr.siamois.infrastructure.database.repositories.vocabulary.dto.ConceptAutocompleteDTO;
+import fr.siamois.mapper.ActionUnitMapper;
 import fr.siamois.mapper.InstitutionMapper;
 import fr.siamois.mapper.PersonMapper;
 import lombok.RequiredArgsConstructor;
@@ -31,10 +32,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Service for managing field configurations of the vocabulary.
@@ -56,6 +54,7 @@ public class FieldConfigurationService {
     private final ConceptFieldConfigRepository conceptFieldConfigRepository;
     private final AutocompleteRepository autocompleteRepository;
     private final InstitutionMapper institutionMapper;
+    private final ActionUnitMapper actionUnitMapper;
 
     private boolean containsFieldCode(FullInfoDTO conceptDTO) {
         return conceptDTO.getFieldcode().isPresent();
@@ -118,6 +117,41 @@ public class FieldConfigurationService {
         return setupFieldConfiguration(institution, vocabulary, new ProgressWrapper());
     }
 
+    /**
+     * Sets up the field configuration for a project (action unit) based on the vocabulary.
+     * The created configurations override the institution ones for this action unit only.
+     *
+     * @param actionUnit      the action unit to configure
+     * @param vocabulary      the vocabulary to use for configuration
+     * @param progressWrapper the progress tracker
+     * @return an Optional containing GlobalFieldConfig if the configuration is wrong, otherwise empty
+     * @throws NotSiamoisThesaurusException      if the vocabulary is not a Siamois thesaurus
+     * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
+     */
+    @NonNull
+    @Transactional(rollbackFor = ErrorProcessingExpansionException.class)
+    public Optional<FeedbackFieldConfig> setupFieldConfigurationForActionUnit(@NonNull ActionUnitDTO actionUnit,
+                                                                             @NonNull Vocabulary vocabulary,
+                                                                             @NonNull ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
+        return setupFieldConfiguration(actionUnit.getCreatedByInstitution(), actionUnit, vocabulary, progressWrapper);
+    }
+
+    /**
+     * Wrapper to call setupFieldConfigurationForActionUnit without progress tracking.
+     *
+     * @param actionUnit the action unit to configure
+     * @param vocabulary the vocabulary to use for configuration
+     * @return an Optional containing GlobalFieldConfig if the configuration is wrong, otherwise empty
+     * @throws NotSiamoisThesaurusException      if the vocabulary is not a Siamois thesaurus
+     * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
+     */
+    @NonNull
+    @Transactional(rollbackFor = ErrorProcessingExpansionException.class)
+    public Optional<FeedbackFieldConfig> setupFieldConfigurationForActionUnit(@NonNull ActionUnitDTO actionUnit,
+                                                                             @NonNull Vocabulary vocabulary) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
+        return setupFieldConfiguration(actionUnit.getCreatedByInstitution(), actionUnit, vocabulary, new ProgressWrapper());
+    }
+
     private FeedbackFieldConfig createConfigOfThesaurus(ConceptBranchDTO conceptBranchDTO) {
         final List<String> existingFieldCodes = fieldService.searchAllFieldCodes();
         final List<FullInfoDTO> allConceptsWithPotentialFieldCode = conceptBranchDTO.getData().values().stream()
@@ -143,6 +177,13 @@ public class FieldConfigurationService {
     private Optional<FeedbackFieldConfig> setupFieldConfiguration(@NonNull InstitutionDTO institutionDTO,
                                                                   @NonNull Vocabulary vocabulary,
                                                                   @NonNull ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
+        return setupFieldConfiguration(institutionDTO, null, vocabulary, progressWrapper);
+    }
+
+    private Optional<FeedbackFieldConfig> setupFieldConfiguration(@NonNull InstitutionDTO institutionDTO,
+                                                                  @Nullable ActionUnitDTO actionUnitDTO,
+                                                                  @NonNull Vocabulary vocabulary,
+                                                                  @NonNull ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
         ConceptBranchDTO conceptBranchDTO = conceptApi.fetchFieldsBranch(vocabulary);
         FeedbackFieldConfig config = createConfigOfThesaurus(conceptBranchDTO);
         if (config.isWrongConfig()) log.warn("Missing code in thesaurus configuration: "+config.missingFieldCode());
@@ -156,19 +197,24 @@ public class FieldConfigurationService {
             ConceptFieldConfig fieldConfig;
             Optional<ConceptFieldConfig> optConfig;
 
-            optConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(institutionDTO.getId(), fieldCode);
+            if (Objects.isNull(actionUnitDTO)) {
+                optConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(institutionDTO.getId(), fieldCode);
+            } else {
+                optConfig = conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(fieldCode, actionUnitDTO.getId());
+            }
 
             if (optConfig.isEmpty()) {
                 Institution institution = institutionMapper.invertConvert(institutionDTO);
                 fieldConfig = new ConceptFieldConfig();
                 fieldConfig.setInstitution(institution);
+                if (actionUnitDTO != null) fieldConfig.setActionUnit(actionUnitMapper.invertConvert(actionUnitDTO));
                 fieldConfig.setFieldCode(fieldCode);
                 fieldConfig.setConcept(concept);
-                fieldConfig = conceptFieldConfigRepository.save(fieldConfig);
             } else {
                 fieldConfig = optConfig.get();
                 fieldConfig.setConcept(concept); // update concept also if there is already a field config
             }
+            fieldConfig = conceptFieldConfigRepository.save(fieldConfig);
 
 
 
@@ -240,11 +286,11 @@ public class FieldConfigurationService {
     }
 
     /**
-     * Finds the configuration for a specific field code for a user.
+     * Finds the configuration for a specific field code for an institution.
      *
      * @param info      the user information containing institution and user details
      * @param fieldCode the field code for which to find the configuration
-     * @return The user configuration if exists, otherwise the institution configuration
+     * @return The institution configuration
      * @throws NoConfigForFieldException if no configuration is found for the field code
      */
     @NonNull
@@ -257,6 +303,15 @@ public class FieldConfigurationService {
         return institutionConfig.get();
     }
 
+    /**
+     * Searchs the configuration for a specific field for a project. If none set, falls back to the institution configuration
+     * @param info the user information containing institution and user details
+     * @param fieldCode the field code for which to find the configuration
+     * @param actionUnitDTO The project to find the config for
+     * @return The project configuration if exists, otherwise the institution configuration
+     * @throws NoConfigForFieldException if no configuration is found for the field code
+     */
+    @NonNull
     public ConceptFieldConfig findConfigurationForFieldCode(@NonNull UserInfo info, @NonNull String fieldCode, @NonNull ActionUnitDTO actionUnitDTO) throws NoConfigForFieldException {
         Optional<ConceptFieldConfig> projectConfig = conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(fieldCode, actionUnitDTO.getId());
         if (projectConfig.isEmpty()) {

--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -2,7 +2,6 @@ package fr.siamois.domain.services.vocabulary;
 
 import fr.siamois.annotations.ExecutionTimeLogger;
 import fr.siamois.domain.models.UserInfo;
-import fr.siamois.domain.models.auth.Person;
 import fr.siamois.domain.models.exceptions.ErrorProcessingExpansionException;
 import fr.siamois.domain.models.exceptions.api.NotSiamoisThesaurusException;
 import fr.siamois.domain.models.exceptions.vocabulary.NoConfigForFieldException;
@@ -14,7 +13,6 @@ import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.models.vocabulary.FeedbackFieldConfig;
 import fr.siamois.domain.models.vocabulary.Vocabulary;
 import fr.siamois.dto.entity.InstitutionDTO;
-import fr.siamois.dto.entity.PersonDTO;
 import fr.siamois.infrastructure.api.ConceptApi;
 import fr.siamois.infrastructure.api.dto.ConceptBranchDTO;
 import fr.siamois.infrastructure.api.dto.FullInfoDTO;
@@ -88,7 +86,7 @@ public class FieldConfigurationService {
      * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
      */
     public Optional<FeedbackFieldConfig> setupFieldConfigurationForInstitution(InstitutionDTO institution, Vocabulary vocabulary, ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        return setupFieldConfiguration(institution, null, vocabulary, progressWrapper);
+        return setupFieldConfiguration(institution, vocabulary, progressWrapper);
     }
 
     /**
@@ -117,7 +115,7 @@ public class FieldConfigurationService {
      */
     @NonNull
     public Optional<FeedbackFieldConfig> setupFieldConfigurationForInstitution(@NonNull InstitutionDTO institution, @NonNull Vocabulary vocabulary) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        return setupFieldConfiguration(institution, null, vocabulary, new ProgressWrapper());
+        return setupFieldConfiguration(institution, vocabulary, new ProgressWrapper());
     }
 
     private FeedbackFieldConfig createConfigOfThesaurus(ConceptBranchDTO conceptBranchDTO) {
@@ -142,36 +140,7 @@ public class FieldConfigurationService {
         return new FeedbackFieldConfig(missingFieldCode, validConcept);
     }
 
-    /**
-     * Sets up the field configuration for a user based on the vocabulary.
-     *
-     * @param info       the user information containing institution and user details
-     * @param vocabulary the vocabulary to use for configuration
-     * @return an Optional containing GlobalFieldConfig if the configuration is wrong, otherwise empty
-     * @throws NotSiamoisThesaurusException      if the vocabulary is not a Siamois thesaurus
-     * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
-     */
-    @NonNull
-    public Optional<FeedbackFieldConfig> setupFieldConfigurationForUser(@NonNull UserInfo info, @NonNull Vocabulary vocabulary) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        return setupFieldConfiguration(info.getInstitution(), info.getUser(), vocabulary, new ProgressWrapper());
-    }
-
-    /**
-     * Sets up the field configuration for a user based on the vocabulary.
-     *
-     * @param info            the user information containing institution and user details
-     * @param vocabulary      the vocabulary to use for configuration
-     * @param progressWrapper the progress wrapper to track progress
-     * @throws NotSiamoisThesaurusException      if the vocabulary is not a Siamois thesaurus
-     * @throws ErrorProcessingExpansionException if there is an error processing the vocabulary expansion
-     */
-    public void setupFieldConfigurationForUser(@NonNull UserInfo info, @NonNull Vocabulary vocabulary, ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        setupFieldConfiguration(info.getInstitution(), info.getUser(), vocabulary, progressWrapper);
-    }
-
-
     private Optional<FeedbackFieldConfig> setupFieldConfiguration(@NonNull InstitutionDTO institutionDTO,
-                                                                  @Nullable PersonDTO userDTO,
                                                                   @NonNull Vocabulary vocabulary,
                                                                   @NonNull ProgressWrapper progressWrapper) throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
         ConceptBranchDTO conceptBranchDTO = conceptApi.fetchFieldsBranch(vocabulary);
@@ -187,18 +156,12 @@ public class FieldConfigurationService {
             ConceptFieldConfig fieldConfig;
             Optional<ConceptFieldConfig> optConfig;
 
-            if (userDTO == null) {
-                optConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(institutionDTO.getId(), fieldCode);
-            } else {
-                optConfig = conceptFieldConfigRepository.findOneByFieldCodeForUser(userDTO.getId(), institutionDTO.getId(), fieldCode);
-            }
+            optConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(institutionDTO.getId(), fieldCode);
 
             if (optConfig.isEmpty()) {
                 Institution institution = institutionMapper.invertConvert(institutionDTO);
-                Person user = personMapper.invertConvert(userDTO);
                 fieldConfig = new ConceptFieldConfig();
                 fieldConfig.setInstitution(institution);
-                fieldConfig.setUser(user);
                 fieldConfig.setFieldCode(fieldCode);
                 fieldConfig.setConcept(concept);
                 fieldConfig = conceptFieldConfigRepository.save(fieldConfig);
@@ -287,15 +250,11 @@ public class FieldConfigurationService {
     @NonNull
     @ExecutionTimeLogger
     public ConceptFieldConfig findConfigurationForFieldCode(@NonNull UserInfo info, @NonNull String fieldCode) throws NoConfigForFieldException {
-        Optional<ConceptFieldConfig> personConfig = conceptFieldConfigRepository.findOneByFieldCodeForUser(info.getUser().getId(), info.getInstitution().getId(), fieldCode);
-        if (personConfig.isEmpty()) {
-            Optional<ConceptFieldConfig> institutionConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(info.getInstitution().getId(), fieldCode);
-            if (institutionConfig.isEmpty()) {
-                throw new NoConfigForFieldException(fieldCode);
-            }
-            return institutionConfig.get();
+        Optional<ConceptFieldConfig> institutionConfig = conceptFieldConfigRepository.findOneByFieldCodeForInstitution(info.getInstitution().getId(), fieldCode);
+        if (institutionConfig.isEmpty()) {
+            throw new NoConfigForFieldException(fieldCode);
         }
-        return personConfig.get();
+        return institutionConfig.get();
     }
 
     /**

--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -56,7 +56,6 @@ public class FieldConfigurationService {
     private final ConceptFieldConfigRepository conceptFieldConfigRepository;
     private final AutocompleteRepository autocompleteRepository;
     private final InstitutionMapper institutionMapper;
-    private final PersonMapper personMapper;
 
     private boolean containsFieldCode(FullInfoDTO conceptDTO) {
         return conceptDTO.getFieldcode().isPresent();

--- a/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
+++ b/src/main/java/fr/siamois/domain/services/vocabulary/FieldConfigurationService.java
@@ -298,9 +298,7 @@ public class FieldConfigurationService {
     @Transactional(readOnly = true)
     public Map<String, List<ConceptAutocompleteDTO>> fetchAllConfiguredVocabularies(@NonNull UserInfo info) {
         Long institutionId = info.getInstitution().getId();
-        Long personId = info.getUser().getId();
-        List<String> fieldCodes = conceptFieldConfigRepository.findDistinctFieldCodesForInstitutionAndUser(
-                institutionId, personId);
+        List<String> fieldCodes = conceptFieldConfigRepository.findDistinctFieldCodesForInstitution(institutionId);
         Map<String, List<ConceptAutocompleteDTO>> out = new LinkedHashMap<>();
         for (String fieldCode : fieldCodes) {
             try {

--- a/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/ConceptFieldConfigRepository.java
+++ b/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/ConceptFieldConfigRepository.java
@@ -11,21 +11,17 @@ import java.util.Optional;
 @Repository
 public interface ConceptFieldConfigRepository extends CrudRepository<ConceptFieldConfig, Long> {
 
-    @Query(
-            nativeQuery = true,
-            value = "SELECT cfc.* FROM concept_field_config cfc " +
-                    "WHERE cfc.fk_institution_id = :institutionId AND cfc.field_code = :fieldCode AND cfc.fk_user_id IS NULL " +
-                    "LIMIT 1"
-    )
+    @Query("SELECT cfc FROM ConceptFieldConfig cfc " +
+            "WHERE cfc.institution.id = :institutionId " +
+            "AND cfc.fieldCode = :fieldCode " +
+            "AND cfc.actionUnit IS NULL")
     Optional<ConceptFieldConfig> findOneByFieldCodeForInstitution(Long institutionId, String fieldCode);
 
-    @Query(
-            nativeQuery = true,
-            value = "SELECT DISTINCT cfc.field_code FROM concept_field_config cfc "
-                    + "WHERE cfc.fk_institution_id = :institutionId "
-                    + "AND (cfc.fk_user_id IS NULL OR cfc.fk_user_id = :personId) "
-                    + "ORDER BY cfc.field_code"
-    )
-    List<String> findDistinctFieldCodesForInstitutionAndUser(Long institutionId, Long personId);
+
+    @Query("SELECT DISTINCT cfc " +
+            "FROM ConceptFieldConfig cfc " +
+            "WHERE cfc.institution.id = :institutionId " +
+            "ORDER BY cfc.fieldCode")
+    List<String> findDistinctFieldCodesForInstitution(Long institutionId);
 
 }

--- a/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/ConceptFieldConfigRepository.java
+++ b/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/ConceptFieldConfigRepository.java
@@ -24,4 +24,5 @@ public interface ConceptFieldConfigRepository extends CrudRepository<ConceptFiel
             "ORDER BY cfc.fieldCode")
     List<String> findDistinctFieldCodesForInstitution(Long institutionId);
 
+    Optional<ConceptFieldConfig> findOneByFieldCodeAndActionUnitId(String fieldCode, Long actionUnitId);
 }

--- a/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/ConceptFieldConfigRepository.java
+++ b/src/main/java/fr/siamois/infrastructure/database/repositories/vocabulary/ConceptFieldConfigRepository.java
@@ -21,14 +21,6 @@ public interface ConceptFieldConfigRepository extends CrudRepository<ConceptFiel
 
     @Query(
             nativeQuery = true,
-            value = "SELECT cfc.* FROM concept_field_config cfc " +
-                    "WHERE cfc.fk_user_id = :personId AND cfc.fk_institution_id = :institutionId AND cfc.field_code = :fieldCode " +
-                    "LIMIT 1"
-    )
-    Optional<ConceptFieldConfig> findOneByFieldCodeForUser(Long personId, Long institutionId, String fieldCode);
-
-    @Query(
-            nativeQuery = true,
             value = "SELECT DISTINCT cfc.field_code FROM concept_field_config cfc "
                     + "WHERE cfc.fk_institution_id = :institutionId "
                     + "AND (cfc.fk_user_id IS NULL OR cfc.fk_user_id = :personId) "

--- a/src/main/java/fr/siamois/ui/bean/settings/ProfileSettingsBean.java
+++ b/src/main/java/fr/siamois/ui/bean/settings/ProfileSettingsBean.java
@@ -5,9 +5,6 @@ import fr.siamois.domain.models.UserInfo;
 import fr.siamois.domain.models.auth.Person;
 import fr.siamois.domain.models.events.InstitutionChangeEvent;
 import fr.siamois.domain.models.events.LoginEvent;
-import fr.siamois.domain.models.exceptions.ErrorProcessingExpansionException;
-import fr.siamois.domain.models.exceptions.api.InvalidEndpointException;
-import fr.siamois.domain.models.exceptions.api.NotSiamoisThesaurusException;
 import fr.siamois.domain.models.exceptions.auth.InvalidNameException;
 import fr.siamois.domain.models.exceptions.auth.InvalidUserInformationException;
 import fr.siamois.domain.models.exceptions.auth.UserAlreadyExistException;
@@ -17,7 +14,6 @@ import fr.siamois.domain.models.misc.ProgressWrapper;
 import fr.siamois.domain.models.settings.PersonSettings;
 import fr.siamois.domain.models.spatialunit.SpatialUnit;
 import fr.siamois.domain.models.vocabulary.Concept;
-import fr.siamois.domain.models.vocabulary.Vocabulary;
 import fr.siamois.domain.services.InstitutionService;
 import fr.siamois.domain.services.LangService;
 import fr.siamois.domain.services.person.PersonService;
@@ -44,8 +40,6 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-
-import static fr.siamois.utils.MessageUtils.displayErrorMessage;
 
 @Slf4j
 @Getter
@@ -158,34 +152,7 @@ public class ProfileSettingsBean implements Serializable {
     }
 
     public void saveThesaurusUserConfig() {
-        if (fThesaurusUrl == null || fThesaurusUrl.isEmpty()) {
-            MessageUtils.displayMessage(langBean, FacesMessage.SEVERITY_WARN, "myProfile.thesaurus.message.missing");
-            return;
-        }
-
-        if (refConfigConcept != null && refConfigConcept.getVocabulary().getUri().equals(fThesaurusUrl)) {
-            MessageUtils.displayMessage(langBean, FacesMessage.SEVERITY_WARN, "myProfile.thesaurus.message.unchanged");
-            return;
-        }
-
-        UserInfo info = sessionSettingsBean.getUserInfo();
-        try {
-            Vocabulary vocabulary = vocabularyService.findOrCreateVocabularyOfUri(fThesaurusUrl);
-            fieldConfigurationService.setupFieldConfigurationForUser(info, vocabulary, progressWrapper);
-            MessageUtils.displayMessage(langBean, FacesMessage.SEVERITY_INFO, "myProfile.thesaurus.message.success");
-            refConfigConcept = fieldConfigurationService.findParentConceptForFieldcode(info, SpatialUnit.CATEGORY_FIELD_CODE);
-        } catch (InvalidEndpointException e) {
-            MessageUtils.displayMessage(langBean, FacesMessage.SEVERITY_ERROR, "myProfile.thesaurus.uri.invalid");
-        } catch (NotSiamoisThesaurusException e) {
-            MessageUtils.displayMessage(langBean, FacesMessage.SEVERITY_ERROR, "myProfile.thesaurus.siamois.invalid");
-        } catch (ErrorProcessingExpansionException e) {
-            displayErrorMessage(langBean, "thesaurus.error.processingExpansion");
-        } catch (NoConfigForFieldException e) {
-            log.error("Unexpected error after setting up thesaurus for user", e);
-            displayErrorMessage(langBean, "common.error.internal");
-        } finally {
-            progressWrapper.reset();
-        }
+        MessageUtils.displayMessage(langBean, FacesMessage.SEVERITY_WARN, "common.warn.notImplemented");
     }
 
     public List<Locale> getRefLangs() {

--- a/src/main/resources/META-INF/resources/template.xhtml
+++ b/src/main/resources/META-INF/resources/template.xhtml
@@ -290,14 +290,6 @@
                                 <p:tooltip for="myProfileLink" value="#{langBean.msg('nav.myProfile.hint')}"/>
                             </h:commandLink>
                         </li>
-                        <li class="nav-item">
-                            <h:commandLink action="#{redirectBean.redirectTo('/settings/profile/thesaurus')}"
-                                           styleClass="nav-link" id="myThesaurusLink">
-                                <i class="bi bi-table"/>
-                                <span class="menu-text">#{langBean.msg('nav.myThesaurus')}</span>
-                                <p:tooltip for="myThesaurusLink" value="#{langBean.msg('nav.myThesaurus.hint')}"/>
-                            </h:commandLink>
-                        </li>
                     </ul>
 
                     <ul class="nav flex-column">

--- a/src/main/resources/language/messages.properties
+++ b/src/main/resources/language/messages.properties
@@ -450,6 +450,7 @@ actionUnit.settings.help.numericalFormat=To specify a format for a field with a 
 actionUnit.settings.help.textualFormat=To specify a format for a field with a textual value, use 'X's. Example: {TYPE_UE:XX}. Does not work with the action unit identifier. Invalid key is %s
 common.message.errorOpeningNewEntityDialog=An error occured while opening the new entity dialog. Please contact administrator.
 common.error.savingNotImplemented=Saving not implemented for this table
+common.warn.notImplemented=This feature is not implemented yet.
 recordingunit.field.stratigraphicRelationships=Stratigraphic relationships
 label.resultsPerPage=Rows per page
 nav.configuration=Configuration

--- a/src/main/resources/language/messages_fr.properties
+++ b/src/main/resources/language/messages_fr.properties
@@ -395,6 +395,7 @@ actionUnit.settings.help.numericalFormat=Pour spécifier le format d'un champ av
 actionUnit.settings.help.textualFormat=Pour spécifier le format d'un champ avec une valeur textuelle, il faut utiliser des X. Exemple : {TYPE_UE:XX}. Ne fonctionne pas avec l'identifiant de l'unité d'action. La clé avec le mauvais format est %s
 common.message.errorOpeningNewEntityDialog=Une erreur est survenue lors de l’ouverture de la boîte de dialogue. Contactez un administrateur.
 common.error.savingNotImplemented=Sauvegarde non implémenté pour cette liste
+common.warn.notImplemented=Cette fonctionnalité n'est pas encore implémentée.
 recordingunit.field.stratigraphicRelationships=Relations stratigraphiques
 table.columnvisibility=Afficher/masquer les colonnes
 label.resultsPerPage=Résultats par page

--- a/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
@@ -314,8 +314,8 @@ class FieldConfigurationServiceTest {
     @Test
     void fetchAllConfiguredVocabularies_returnsMapPerFieldCode()  {
         String fieldCode = "TESTFIELD";
-        when(conceptFieldConfigRepository.findDistinctFieldCodesForInstitutionAndUser(
-                userInfo.getInstitution().getId(), userInfo.getUser().getId()))
+        when(conceptFieldConfigRepository.findDistinctFieldCodesForInstitution(
+                userInfo.getInstitution().getId()))
                 .thenReturn(List.of(fieldCode));
 
         ConceptFieldConfig cfc = new ConceptFieldConfig();

--- a/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
@@ -204,12 +204,14 @@ class FieldConfigurationServiceTest {
                 .thenReturn(savedConcept);
         when(conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId("SIATEST", 42L))
                 .thenReturn(Optional.of(existing));
+        when(conceptFieldConfigRepository.save(any(ConceptFieldConfig.class))).thenAnswer(i -> i.getArgument(0));
 
         Optional<FeedbackFieldConfig> result = service.setupFieldConfigurationForActionUnit(actionUnitDTO, vocabulary, new ProgressWrapper());
 
         assertThat(result).isEmpty();
         assertThat(existing.getConcept()).isEqualTo(savedConcept);
-        verify(conceptFieldConfigRepository, never()).save(any(ConceptFieldConfig.class));
+        // the existing config is updated in place, no new one is created
+        verify(conceptFieldConfigRepository).save(existing);
         verifyNoInteractions(actionUnitMapper);
         verify(conceptService).saveAllSubConceptOfIfUpdated(eq(existing), any(ProgressWrapper.class));
     }
@@ -491,19 +493,19 @@ class FieldConfigurationServiceTest {
     }
 
     @Test
-    void fetchAutocompleteRelated_shouldPreferUserConfigOverInstitutionConfig() throws NoConfigForFieldException {
+    void fetchAutocompleteRelated_shouldForwardNullInput_asIs() throws NoConfigForFieldException {
         String fieldCode = "TESTFIELD";
 
-        Concept userFieldConcept = new Concept();
-        userFieldConcept.setVocabulary(vocabulary);
-        userFieldConcept.setExternalId("user-field-concept");
+        Concept fieldConcept = new Concept();
+        fieldConcept.setVocabulary(vocabulary);
+        fieldConcept.setExternalId("field-concept");
 
-        ConceptFieldConfig userConfig = new ConceptFieldConfig();
-        userConfig.setConcept(userFieldConcept);
-        userConfig.setFieldCode(fieldCode);
+        ConceptFieldConfig cfc = new ConceptFieldConfig();
+        cfc.setConcept(fieldConcept);
+        cfc.setFieldCode(fieldCode);
 
-        when(conceptFieldConfigRepository.findOneByFieldCodeForUser(userInfo.getUser().getId(), userInfo.getInstitution().getId(), fieldCode))
-                .thenReturn(Optional.of(userConfig));
+        when(conceptFieldConfigRepository.findOneByFieldCodeForInstitution(userInfo.getInstitution().getId(), fieldCode))
+                .thenReturn(Optional.of(cfc));
 
         Concept baseValue = new Concept();
         baseValue.setVocabulary(vocabulary);
@@ -511,9 +513,8 @@ class FieldConfigurationServiceTest {
 
         service.fetchAutocompleteRelated(userInfo, fieldCode, baseValue, null);
 
-        verify(conceptFieldConfigRepository, never()).findOneByFieldCodeForInstitution(anyLong(), anyString());
         // a null input is forwarded as-is, the SQL function treats it as "no text filter"
-        verify(autocompleteRepository).findMatchingConceptsFromRelatedFor(userFieldConcept, baseValue, "fr", null, FieldConfigurationService.LIMIT_RESULTS);
+        verify(autocompleteRepository).findMatchingConceptsFromRelatedFor(fieldConcept, baseValue, "fr", null, FieldConfigurationService.LIMIT_RESULTS);
     }
 
     @Test

--- a/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
@@ -366,8 +366,8 @@ class FieldConfigurationServiceTest {
     @Test
     void fetchAllConfiguredVocabularies_returnsMapPerFieldCode() {
         String fieldCode = "TESTFIELD";
-        when(conceptFieldConfigRepository.findDistinctFieldCodesForInstitutionAndUser(
-                userInfo.getInstitution().getId(), userInfo.getUser().getId()))
+        when(conceptFieldConfigRepository.findDistinctFieldCodesForInstitution(
+                userInfo.getInstitution().getId()))
                 .thenReturn(List.of(fieldCode));
 
         ConceptFieldConfig cfc = new ConceptFieldConfig();

--- a/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
@@ -1,11 +1,9 @@
 package fr.siamois.domain.services.vocabulary;
 
 import fr.siamois.domain.models.UserInfo;
-import fr.siamois.domain.models.auth.Person;
 import fr.siamois.domain.models.exceptions.ErrorProcessingExpansionException;
 import fr.siamois.domain.models.exceptions.api.NotSiamoisThesaurusException;
 import fr.siamois.domain.models.exceptions.vocabulary.NoConfigForFieldException;
-import fr.siamois.domain.models.institution.Institution;
 import fr.siamois.domain.models.misc.ProgressWrapper;
 import fr.siamois.domain.models.settings.ConceptFieldConfig;
 import fr.siamois.domain.models.spatialunit.SpatialUnit;
@@ -146,56 +144,6 @@ class FieldConfigurationServiceTest {
     void setupFieldConfigurationForInstitution_shouldThrowErrorProcessingExpansionException_whenResponseIsInvalid() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
         when(conceptApi.fetchFieldsBranch(vocabulary)).thenThrow(ErrorProcessingExpansionException.class);
         assertThrows(ErrorProcessingExpansionException.class, () -> service.setupFieldConfigurationForInstitution(userInfo, vocabulary));
-    }
-
-    @Test
-    void setupFieldConfigurationForUser_shouldReturnFieldConfigIfWrong_whenMissingFieldCodes() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        when(conceptApi.fetchFieldsBranch(vocabulary)).thenReturn(conceptBranchDTO);
-        when(fieldService.searchAllFieldCodes()).thenReturn(List.of("SIATEST", "SIATEST2", "SIATEST3"));
-
-        Optional<FeedbackFieldConfig> result = service.setupFieldConfigurationForUser(userInfo, vocabulary);
-
-        assertThat(result).isPresent();
-    }
-
-    @Test
-    void setupFieldConfigurationForUser_shouldReturnEmptyWhenValid_andConfigDoesNotExist() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        when(conceptApi.fetchFieldsBranch(vocabulary)).thenReturn(conceptBranchDTO);
-        when(fieldService.searchAllFieldCodes()).thenReturn(List.of("SIATEST", "SIATEST2"));
-        doAnswer(i -> {
-            Vocabulary vocab = i.getArgument(0);
-            FullInfoDTO dto = i.getArgument(1);
-            Concept concept = new Concept();
-            concept.setVocabulary(vocab);
-            concept.setExternalId(dto.getIdentifier()[0].getValue());
-            return concept;
-        }).when(conceptService).saveOrGetConceptFromFullDTO(any(Vocabulary.class), any(FullInfoDTO.class), eq(null));
-
-        Institution institution  = new Institution();
-        institution.setId(12L);
-
-        when(institutionMapper.invertConvert(any(InstitutionDTO.class))).thenReturn(institution);
-        when(personMapper.invertConvert(any(PersonDTO.class))).thenReturn(new Person());
-        when(conceptFieldConfigRepository.findOneByFieldCodeForUser(eq(userInfo.getUser().getId()), eq(userInfo.getInstitution().getId()),anyString())).thenReturn(Optional.empty());
-        when(conceptFieldConfigRepository.save(any(ConceptFieldConfig.class))).thenAnswer(i -> i.getArgument(0));
-
-        Optional<FeedbackFieldConfig> result = service.setupFieldConfigurationForUser(userInfo, vocabulary);
-
-        assertThat(result).isEmpty();
-        verify(conceptFieldConfigRepository, times(2)).save(any(ConceptFieldConfig.class));
-        verify(conceptService, times(2)).saveAllSubConceptOfIfUpdated(any(ConceptFieldConfig.class), any(ProgressWrapper.class));
-    }
-
-    @Test
-    void setupFieldConfigurationForUser_shouldThrowNotSiamoisThesaurusException_whenSIAAUTOCOMPLETEmissing() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        when(conceptApi.fetchFieldsBranch(vocabulary)).thenThrow(NotSiamoisThesaurusException.class);
-        assertThrows(NotSiamoisThesaurusException.class, () -> service.setupFieldConfigurationForUser(userInfo, vocabulary));
-    }
-
-    @Test
-    void setupFieldConfigurationForUser_shouldThrowErrorProcessingExpansionException_whenResponseIsInvalid() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
-        when(conceptApi.fetchFieldsBranch(vocabulary)).thenThrow(ErrorProcessingExpansionException.class);
-        assertThrows(ErrorProcessingExpansionException.class, () -> service.setupFieldConfigurationForUser(userInfo, vocabulary));
     }
 
     @Test

--- a/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
+++ b/src/test/java/fr/siamois/domain/services/vocabulary/FieldConfigurationServiceTest.java
@@ -11,6 +11,7 @@ import fr.siamois.domain.models.vocabulary.Concept;
 import fr.siamois.domain.models.vocabulary.FeedbackFieldConfig;
 import fr.siamois.domain.models.vocabulary.Vocabulary;
 import fr.siamois.domain.models.vocabulary.VocabularyType;
+import fr.siamois.dto.entity.ActionUnitDTO;
 import fr.siamois.dto.entity.ConceptDTO;
 import fr.siamois.dto.entity.InstitutionDTO;
 import fr.siamois.dto.entity.PersonDTO;
@@ -21,11 +22,14 @@ import fr.siamois.infrastructure.database.repositories.vocabulary.AutocompleteRe
 import fr.siamois.infrastructure.database.repositories.vocabulary.ConceptFieldConfigRepository;
 import fr.siamois.infrastructure.database.repositories.vocabulary.ConceptRepository;
 import fr.siamois.infrastructure.database.repositories.vocabulary.dto.ConceptAutocompleteDTO;
+import fr.siamois.domain.models.actionunit.ActionUnit;
+import fr.siamois.mapper.ActionUnitMapper;
 import fr.siamois.mapper.InstitutionMapper;
 import fr.siamois.mapper.PersonMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -61,6 +65,9 @@ class FieldConfigurationServiceTest {
 
     @Mock
     private InstitutionMapper institutionMapper;
+
+    @Mock
+    private ActionUnitMapper actionUnitMapper;
 
     @Mock
     private PersonMapper personMapper;
@@ -144,6 +151,100 @@ class FieldConfigurationServiceTest {
     void setupFieldConfigurationForInstitution_shouldThrowErrorProcessingExpansionException_whenResponseIsInvalid() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
         when(conceptApi.fetchFieldsBranch(vocabulary)).thenThrow(ErrorProcessingExpansionException.class);
         assertThrows(ErrorProcessingExpansionException.class, () -> service.setupFieldConfigurationForInstitution(userInfo, vocabulary));
+    }
+
+    @Test
+    void setupFieldConfigurationForActionUnit_shouldCreateConfigLinkedToActionUnit_whenNoneExists() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
+        ActionUnitDTO actionUnitDTO = actionUnitDTO(42L);
+        ActionUnit actionUnit = new ActionUnit();
+        actionUnit.setId(42L);
+
+        when(conceptApi.fetchFieldsBranch(vocabulary)).thenReturn(conceptBranchDTO);
+        when(fieldService.searchAllFieldCodes()).thenReturn(List.of("SIATEST", "SIATEST2"));
+        when(conceptService.saveOrGetConceptFromFullDTO(any(Vocabulary.class), any(FullInfoDTO.class), eq(null)))
+                .thenAnswer(i -> {
+                    Concept concept = new Concept();
+                    concept.setVocabulary(i.getArgument(0));
+                    concept.setExternalId(((FullInfoDTO) i.getArgument(1)).getIdentifier()[0].getValue());
+                    return concept;
+                });
+        when(conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(anyString(), eq(42L)))
+                .thenReturn(Optional.empty());
+        when(actionUnitMapper.invertConvert(actionUnitDTO)).thenReturn(actionUnit);
+        when(conceptFieldConfigRepository.save(any(ConceptFieldConfig.class))).thenAnswer(i -> i.getArgument(0));
+
+        Optional<FeedbackFieldConfig> result = service.setupFieldConfigurationForActionUnit(actionUnitDTO, vocabulary);
+
+        assertThat(result).isEmpty();
+
+        ArgumentCaptor<ConceptFieldConfig> captor = ArgumentCaptor.forClass(ConceptFieldConfig.class);
+        verify(conceptFieldConfigRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues())
+                .allSatisfy(saved -> assertThat(saved.getActionUnit()).isEqualTo(actionUnit))
+                .extracting(ConceptFieldConfig::getFieldCode)
+                .containsExactlyInAnyOrder("SIATEST", "SIATEST2");
+        verify(conceptFieldConfigRepository, never()).findOneByFieldCodeForInstitution(anyLong(), anyString());
+        verify(conceptService, times(2)).saveAllSubConceptOfIfUpdated(any(ConceptFieldConfig.class), any(ProgressWrapper.class));
+    }
+
+    @Test
+    void setupFieldConfigurationForActionUnit_shouldUpdateExistingConfig_whenAlreadyExists() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
+        ActionUnitDTO actionUnitDTO = actionUnitDTO(42L);
+
+        ConceptFieldConfig existing = new ConceptFieldConfig();
+        existing.setFieldCode("SIATEST");
+
+        Concept savedConcept = new Concept();
+        savedConcept.setVocabulary(vocabulary);
+        savedConcept.setExternalId("12");
+
+        when(conceptApi.fetchFieldsBranch(vocabulary)).thenReturn(conceptBranchDTO);
+        when(fieldService.searchAllFieldCodes()).thenReturn(List.of("SIATEST"));
+        when(conceptService.saveOrGetConceptFromFullDTO(any(Vocabulary.class), any(FullInfoDTO.class), eq(null)))
+                .thenReturn(savedConcept);
+        when(conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId("SIATEST", 42L))
+                .thenReturn(Optional.of(existing));
+
+        Optional<FeedbackFieldConfig> result = service.setupFieldConfigurationForActionUnit(actionUnitDTO, vocabulary, new ProgressWrapper());
+
+        assertThat(result).isEmpty();
+        assertThat(existing.getConcept()).isEqualTo(savedConcept);
+        verify(conceptFieldConfigRepository, never()).save(any(ConceptFieldConfig.class));
+        verifyNoInteractions(actionUnitMapper);
+        verify(conceptService).saveAllSubConceptOfIfUpdated(eq(existing), any(ProgressWrapper.class));
+    }
+
+    @Test
+    void setupFieldConfigurationForActionUnit_shouldReturnFeedback_whenMissingFieldCodes() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
+        ActionUnitDTO actionUnitDTO = actionUnitDTO(42L);
+
+        when(conceptApi.fetchFieldsBranch(vocabulary)).thenReturn(conceptBranchDTO);
+        when(fieldService.searchAllFieldCodes()).thenReturn(List.of("SIATEST", "SIATEST2", "SIATEST3"));
+        when(conceptService.saveOrGetConceptFromFullDTO(any(Vocabulary.class), any(FullInfoDTO.class), eq(null)))
+                .thenReturn(new Concept());
+        when(conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(anyString(), eq(42L)))
+                .thenReturn(Optional.of(new ConceptFieldConfig()));
+
+        Optional<FeedbackFieldConfig> result = service.setupFieldConfigurationForActionUnit(actionUnitDTO, vocabulary);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().missingFieldCode()).containsExactly("SIATEST3");
+    }
+
+    @Test
+    void setupFieldConfigurationForActionUnit_shouldThrowNotSiamoisThesaurusException_whenVocabularyIsNotSiamois() throws NotSiamoisThesaurusException, ErrorProcessingExpansionException {
+        ActionUnitDTO actionUnitDTO = actionUnitDTO(42L);
+        when(conceptApi.fetchFieldsBranch(vocabulary)).thenThrow(NotSiamoisThesaurusException.class);
+
+        assertThrows(NotSiamoisThesaurusException.class,
+                () -> service.setupFieldConfigurationForActionUnit(actionUnitDTO, vocabulary));
+    }
+
+    private ActionUnitDTO actionUnitDTO(Long id) {
+        ActionUnitDTO actionUnitDTO = new ActionUnitDTO();
+        actionUnitDTO.setId(id);
+        actionUnitDTO.setCreatedByInstitution(userInfo.getInstitution());
+        return actionUnitDTO;
     }
 
     @Test
@@ -250,6 +351,63 @@ class FieldConfigurationServiceTest {
     @Test
     void findConfigurationForFieldCode_shouldThrowNoConfigException_whenConfigDoesNotExist() {
         assertThrows(NoConfigForFieldException.class, () -> service.findConfigurationForFieldCode(userInfo, SpatialUnit.CATEGORY_FIELD_CODE));
+    }
+
+    @Test
+    void findConfigurationForFieldCodeWithActionUnit_shouldReturnActionUnitConfig_whenExists() throws NoConfigForFieldException {
+        ActionUnitDTO actionUnit = new ActionUnitDTO();
+        actionUnit.setId(42L);
+
+        ConceptFieldConfig actionUnitConfig = new ConceptFieldConfig();
+        Concept concept = new Concept();
+        concept.setVocabulary(vocabulary);
+        concept.setExternalId("12");
+        actionUnitConfig.setConcept(concept);
+        actionUnitConfig.setFieldCode(SpatialUnit.CATEGORY_FIELD_CODE);
+
+        when(conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(SpatialUnit.CATEGORY_FIELD_CODE, 42L))
+                .thenReturn(Optional.of(actionUnitConfig));
+
+        ConceptFieldConfig result = service.findConfigurationForFieldCode(userInfo, SpatialUnit.CATEGORY_FIELD_CODE, actionUnit);
+
+        assertThat(result).isEqualTo(actionUnitConfig);
+        verify(conceptFieldConfigRepository, never()).findOneByFieldCodeForInstitution(anyLong(), anyString());
+    }
+
+    @Test
+    void findConfigurationForFieldCodeWithActionUnit_shouldFallbackOnInstitutionConfig_whenNoActionUnitConfig() throws NoConfigForFieldException {
+        ActionUnitDTO actionUnit = new ActionUnitDTO();
+        actionUnit.setId(42L);
+
+        ConceptFieldConfig institutionConfig = new ConceptFieldConfig();
+        Concept concept = new Concept();
+        concept.setVocabulary(vocabulary);
+        concept.setExternalId("12");
+        institutionConfig.setConcept(concept);
+        institutionConfig.setFieldCode(SpatialUnit.CATEGORY_FIELD_CODE);
+
+        when(conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(SpatialUnit.CATEGORY_FIELD_CODE, 42L))
+                .thenReturn(Optional.empty());
+        when(conceptFieldConfigRepository.findOneByFieldCodeForInstitution(userInfo.getInstitution().getId(), SpatialUnit.CATEGORY_FIELD_CODE))
+                .thenReturn(Optional.of(institutionConfig));
+
+        ConceptFieldConfig result = service.findConfigurationForFieldCode(userInfo, SpatialUnit.CATEGORY_FIELD_CODE, actionUnit);
+
+        assertThat(result).isEqualTo(institutionConfig);
+    }
+
+    @Test
+    void findConfigurationForFieldCodeWithActionUnit_shouldThrowNoConfigException_whenNoConfigAtAll() {
+        ActionUnitDTO actionUnit = new ActionUnitDTO();
+        actionUnit.setId(42L);
+
+        when(conceptFieldConfigRepository.findOneByFieldCodeAndActionUnitId(SpatialUnit.CATEGORY_FIELD_CODE, 42L))
+                .thenReturn(Optional.empty());
+        when(conceptFieldConfigRepository.findOneByFieldCodeForInstitution(userInfo.getInstitution().getId(), SpatialUnit.CATEGORY_FIELD_CODE))
+                .thenReturn(Optional.empty());
+
+        assertThrows(NoConfigForFieldException.class,
+                () -> service.findConfigurationForFieldCode(userInfo, SpatialUnit.CATEGORY_FIELD_CODE, actionUnit));
     }
 
     @Test


### PR DESCRIPTION
# Why this PR ?
This PR prepares the backend of the thesaurus configuration at project level.

# What's changed ?
- The configuration is no longer possible at user level (Delete `user` attribute from `ConceptFieldConfig` and associated methods)
- The configuration is now possible at action unit level (Add `actionUnit` attribute from `ConceptFieldConfig`)
- Create method `FieldConfigurationService#setupFieldConfigurationForActionUnit` to create project thesaurus configuration. Created a supercharge without the ProgressWrapper
- Create supercharge `FieldConfigurationService#findConfigurationForFieldCode(UserInfo,String,ActionUnitDTO)` to find configuration from a project. If the configuration does not exists, the methods falls back to the institution supercharge